### PR TITLE
feat: Adding unit test OrderEligibility, RmaSubmitService, StatusReso…

### DIFF
--- a/Service/AttachmentService.php
+++ b/Service/AttachmentService.php
@@ -181,7 +181,7 @@ class AttachmentService
     public function getAbsolutePath(AttachmentInterface $attachment): string
     {
         $resolved = $this->varDirectory->getAbsolutePath($attachment->getFilePath());
-        $basePath = $this->varDirectory->getAbsolutePath(self::BASE_PATH);
+        $basePath = rtrim($this->varDirectory->getAbsolutePath(self::BASE_PATH), '/') . '/';
 
         if (!str_starts_with($resolved, $basePath)) {
             throw new LocalizedException(__('Invalid attachment path.'));

--- a/Test/Unit/Controller/Customer/Attachment/DownloadTest.php
+++ b/Test/Unit/Controller/Customer/Attachment/DownloadTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MageOS\RMA\Test\Unit\Controller\Customer\Attachment;
+
+use MageOS\RMA\Api\AttachmentRepositoryInterface;
+use MageOS\RMA\Api\Data\AttachmentInterface;
+use MageOS\RMA\Api\Data\RMAInterface;
+use MageOS\RMA\Api\RMARepositoryInterface;
+use MageOS\RMA\Controller\Customer\Attachment\Download;
+use MageOS\RMA\Service\AttachmentService;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Controller\Result\RedirectFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class DownloadTest extends TestCase
+{
+    private RequestInterface&MockObject $request;
+    private RedirectFactory&MockObject $resultRedirectFactory;
+    private FileFactory&MockObject $fileFactory;
+    private CustomerSession&MockObject $customerSession;
+    private AttachmentRepositoryInterface&MockObject $attachmentRepository;
+    private RMARepositoryInterface&MockObject $rmaRepository;
+    private AttachmentService&MockObject $attachmentService;
+    private MessageManagerInterface&MockObject $messageManager;
+    private Download $controller;
+
+    protected function setUp(): void
+    {
+        $this->request               = $this->createMock(RequestInterface::class);
+        $this->resultRedirectFactory = $this->createMock(RedirectFactory::class);
+        $this->fileFactory           = $this->createMock(FileFactory::class);
+        $this->customerSession       = $this->createMock(CustomerSession::class);
+        $this->attachmentRepository  = $this->createMock(AttachmentRepositoryInterface::class);
+        $this->rmaRepository         = $this->createMock(RMARepositoryInterface::class);
+        $this->attachmentService     = $this->createMock(AttachmentService::class);
+        $this->messageManager        = $this->createMock(MessageManagerInterface::class);
+
+        $this->controller = new Download(
+            $this->request,
+            $this->resultRedirectFactory,
+            $this->fileFactory,
+            $this->customerSession,
+            $this->attachmentRepository,
+            $this->rmaRepository,
+            $this->attachmentService,
+            $this->messageManager
+        );
+    }
+
+    private function makeRedirect(string $path): Redirect&MockObject
+    {
+        $redirect = $this->createMock(Redirect::class);
+        $redirect->method('setPath')->with($path)->willReturnSelf();
+
+        return $redirect;
+    }
+
+    // -------------------------------------------------------------------------
+    // Authentication gate
+    // -------------------------------------------------------------------------
+
+    public function testRedirectsToLoginWhenCustomerNotLoggedIn(): void
+    {
+        $this->customerSession->method('isLoggedIn')->willReturn(false);
+
+        $redirect = $this->makeRedirect('customer/account/login');
+        $this->resultRedirectFactory->method('create')->willReturn($redirect);
+
+        $result = $this->controller->execute();
+
+        $this->assertSame($redirect, $result);
+    }
+
+    public function testDoesNotAccessRepositoryWhenCustomerNotLoggedIn(): void
+    {
+        $this->customerSession->method('isLoggedIn')->willReturn(false);
+
+        $redirect = $this->createMock(Redirect::class);
+        $redirect->method('setPath')->willReturnSelf();
+        $this->resultRedirectFactory->method('create')->willReturn($redirect);
+
+        $this->attachmentRepository->expects($this->never())->method('get');
+
+        $this->controller->execute();
+    }
+
+    // -------------------------------------------------------------------------
+    // Ownership check — the critical security gate
+    // -------------------------------------------------------------------------
+
+    public function testRedirectsWithErrorWhenRmaDoesNotBelongToCustomer(): void
+    {
+        $this->customerSession->method('isLoggedIn')->willReturn(true);
+        $this->customerSession->method('getCustomerId')->willReturn(42);
+
+        $this->request->method('getParam')->with('id')->willReturn('7');
+
+        $attachment = $this->createMock(AttachmentInterface::class);
+        $attachment->method('getRmaId')->willReturn(10);
+        $this->attachmentRepository->method('get')->with(7)->willReturn($attachment);
+
+        $rma = $this->createMock(RMAInterface::class);
+        $rma->method('getCustomerId')->willReturn(99);
+        $this->rmaRepository->method('get')->with(10)->willReturn($rma);
+
+        $this->messageManager->expects($this->once())
+            ->method('addErrorMessage')
+            ->with($this->anything());
+
+        $redirect = $this->makeRedirect('rma/customer/history');
+        $this->resultRedirectFactory->method('create')->willReturn($redirect);
+
+        $result = $this->controller->execute();
+
+        $this->assertSame($redirect, $result);
+    }
+
+    public function testDoesNotServeFileWhenRmaBelongsToDifferentCustomer(): void
+    {
+        $this->customerSession->method('isLoggedIn')->willReturn(true);
+        $this->customerSession->method('getCustomerId')->willReturn(1);
+
+        $this->request->method('getParam')->with('id')->willReturn('5');
+
+        $attachment = $this->createMock(AttachmentInterface::class);
+        $attachment->method('getRmaId')->willReturn(10);
+        $this->attachmentRepository->method('get')->willReturn($attachment);
+
+        $rma = $this->createMock(RMAInterface::class);
+        $rma->method('getCustomerId')->willReturn(2);
+        $this->rmaRepository->method('get')->willReturn($rma);
+
+        $redirect = $this->createMock(Redirect::class);
+        $redirect->method('setPath')->willReturnSelf();
+        $this->resultRedirectFactory->method('create')->willReturn($redirect);
+
+        $this->attachmentService->expects($this->never())->method('createDownloadResponse');
+
+        $this->controller->execute();
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    public function testReturnsDownloadResponseForAuthorizedCustomer(): void
+    {
+        $this->customerSession->method('isLoggedIn')->willReturn(true);
+        $this->customerSession->method('getCustomerId')->willReturn(42);
+
+        $this->request->method('getParam')->with('id')->willReturn('7');
+
+        $attachment = $this->createMock(AttachmentInterface::class);
+        $attachment->method('getRmaId')->willReturn(10);
+        $this->attachmentRepository->method('get')->with(7)->willReturn($attachment);
+
+        $rma = $this->createMock(RMAInterface::class);
+        $rma->method('getCustomerId')->willReturn(42);
+        $this->rmaRepository->method('get')->with(10)->willReturn($rma);
+
+        $downloadResponse = $this->createMock(ResponseInterface::class);
+        $this->attachmentService->expects($this->once())
+            ->method('createDownloadResponse')
+            ->with($attachment, $this->fileFactory)
+            ->willReturn($downloadResponse);
+
+        $result = $this->controller->execute();
+
+        $this->assertSame($downloadResponse, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Error handling
+    // -------------------------------------------------------------------------
+
+    public function testRedirectsWithErrorWhenAttachmentNotFound(): void
+    {
+        $this->customerSession->method('isLoggedIn')->willReturn(true);
+        $this->request->method('getParam')->willReturn('99');
+
+        $this->attachmentRepository->method('get')
+            ->willThrowException(new NoSuchEntityException(__('Not found')));
+
+        $this->messageManager->expects($this->once())->method('addErrorMessage');
+
+        $redirect = $this->makeRedirect('rma/customer/history');
+        $this->resultRedirectFactory->method('create')->willReturn($redirect);
+
+        $result = $this->controller->execute();
+
+        $this->assertSame($redirect, $result);
+    }
+
+    public function testRedirectsWithErrorOnGenericException(): void
+    {
+        $this->customerSession->method('isLoggedIn')->willReturn(true);
+        $this->customerSession->method('getCustomerId')->willReturn(1);
+
+        $this->request->method('getParam')->willReturn('5');
+
+        $attachment = $this->createMock(AttachmentInterface::class);
+        $attachment->method('getRmaId')->willReturn(10);
+        $this->attachmentRepository->method('get')->willReturn($attachment);
+
+        $rma = $this->createMock(RMAInterface::class);
+        $rma->method('getCustomerId')->willReturn(1);
+        $this->rmaRepository->method('get')->willReturn($rma);
+
+        $this->attachmentService->method('createDownloadResponse')
+            ->willThrowException(new \Exception('Unexpected error'));
+
+        $this->messageManager->expects($this->once())->method('addErrorMessage');
+
+        $redirect = $this->makeRedirect('rma/customer/history');
+        $this->resultRedirectFactory->method('create')->willReturn($redirect);
+
+        $result = $this->controller->execute();
+
+        $this->assertSame($redirect, $result);
+    }
+}

--- a/Test/Unit/Model/AbstractRepositoryTest.php
+++ b/Test/Unit/Model/AbstractRepositoryTest.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MageOS\RMA\Test\Unit\Model;
+
+use MageOS\RMA\Model\AbstractRepository;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SearchResultsInterface;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Concrete subclass that exposes the protected methods under test as public.
+ */
+class ConcreteTestRepository extends AbstractRepository
+{
+    public function __construct(
+        AbstractDb $resourceModel,
+        CollectionProcessorInterface $collectionProcessor,
+        private readonly AbstractModel $entity,
+        private readonly AbstractCollection $collection,
+        private readonly SearchResultsInterface $searchResults,
+        private readonly string $label = 'widget'
+    ) {
+        parent::__construct($resourceModel, $collectionProcessor);
+    }
+
+    protected function getEntityLabel(): string
+    {
+        return $this->label;
+    }
+
+    protected function createEntity(): AbstractModel
+    {
+        return $this->entity;
+    }
+
+    protected function createCollection(): AbstractCollection
+    {
+        return $this->collection;
+    }
+
+    protected function createSearchResults(): SearchResultsInterface
+    {
+        return $this->searchResults;
+    }
+
+    public function load(int $entityId): AbstractModel
+    {
+        return $this->loadEntity($entityId);
+    }
+
+    public function save(AbstractModel $entity): AbstractModel
+    {
+        return $this->saveEntity($entity);
+    }
+
+    public function delete(AbstractModel $entity): bool
+    {
+        return $this->deleteEntity($entity);
+    }
+
+    public function getList(SearchCriteriaInterface $searchCriteria): SearchResultsInterface
+    {
+        return $this->performGetList($searchCriteria);
+    }
+}
+
+class AbstractRepositoryTest extends TestCase
+{
+    private AbstractDb&MockObject $resourceModel;
+    private CollectionProcessorInterface&MockObject $collectionProcessor;
+    private AbstractModel&MockObject $entity;
+    private AbstractCollection&MockObject $collection;
+    private SearchResultsInterface&MockObject $searchResults;
+    private ConcreteTestRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->resourceModel      = $this->createMock(AbstractDb::class);
+        $this->collectionProcessor = $this->createMock(CollectionProcessorInterface::class);
+        $this->entity             = $this->createMock(AbstractModel::class);
+        $this->collection         = $this->createMock(AbstractCollection::class);
+        $this->searchResults      = $this->createMock(SearchResultsInterface::class);
+
+        $this->repository = new ConcreteTestRepository(
+            $this->resourceModel,
+            $this->collectionProcessor,
+            $this->entity,
+            $this->collection,
+            $this->searchResults
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // loadEntity
+    // -------------------------------------------------------------------------
+
+    public function testLoadEntityReturnsEntityWhenFound(): void
+    {
+        $this->entity->method('getEntityId')->willReturn(5);
+
+        $result = $this->repository->load(5);
+
+        $this->assertSame($this->entity, $result);
+    }
+
+    public function testLoadEntityCallsResourceModelWithId(): void
+    {
+        $this->entity->method('getEntityId')->willReturn(5);
+
+        $this->resourceModel->expects($this->once())
+            ->method('load')
+            ->with($this->entity, 5);
+
+        $this->repository->load(5);
+    }
+
+    public function testLoadEntityThrowsNoSuchEntityExceptionWhenNotFound(): void
+    {
+        $this->expectException(NoSuchEntityException::class);
+
+        $this->entity->method('getEntityId')->willReturn(null);
+
+        $this->repository->load(99);
+    }
+
+    public function testLoadEntityExceptionMessageIncludesEntityLabelAndId(): void
+    {
+        $this->entity->method('getEntityId')->willReturn(null);
+
+        try {
+            $this->repository->load(42);
+            $this->fail('Expected NoSuchEntityException');
+        } catch (NoSuchEntityException $e) {
+            $this->assertStringContainsString('widget', $e->getMessage());
+            $this->assertStringContainsString('42', $e->getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // saveEntity
+    // -------------------------------------------------------------------------
+
+    public function testSaveEntityReturnsEntityOnSuccess(): void
+    {
+        $result = $this->repository->save($this->entity);
+
+        $this->assertSame($this->entity, $result);
+    }
+
+    public function testSaveEntityCallsResourceModelSave(): void
+    {
+        $this->resourceModel->expects($this->once())
+            ->method('save')
+            ->with($this->entity);
+
+        $this->repository->save($this->entity);
+    }
+
+    public function testSaveEntityThrowsCouldNotSaveExceptionOnFailure(): void
+    {
+        $this->expectException(CouldNotSaveException::class);
+
+        $this->resourceModel->method('save')
+            ->willThrowException(new \Exception('DB connection lost'));
+
+        $this->repository->save($this->entity);
+    }
+
+    public function testSaveEntityExceptionMessageIncludesEntityLabelAndOriginalMessage(): void
+    {
+        $this->resourceModel->method('save')
+            ->willThrowException(new \Exception('duplicate entry'));
+
+        try {
+            $this->repository->save($this->entity);
+            $this->fail('Expected CouldNotSaveException');
+        } catch (CouldNotSaveException $e) {
+            $this->assertStringContainsString('widget', $e->getMessage());
+            $this->assertStringContainsString('duplicate entry', $e->getMessage());
+        }
+    }
+
+    public function testSaveEntityWrapsOriginalExceptionAsPrevious(): void
+    {
+        $original = new \Exception('original error');
+        $this->resourceModel->method('save')->willThrowException($original);
+
+        try {
+            $this->repository->save($this->entity);
+        } catch (CouldNotSaveException $e) {
+            $this->assertSame($original, $e->getPrevious());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // deleteEntity
+    // -------------------------------------------------------------------------
+
+    public function testDeleteEntityReturnsTrueOnSuccess(): void
+    {
+        $this->assertTrue($this->repository->delete($this->entity));
+    }
+
+    public function testDeleteEntityCallsResourceModelDelete(): void
+    {
+        $this->resourceModel->expects($this->once())
+            ->method('delete')
+            ->with($this->entity);
+
+        $this->repository->delete($this->entity);
+    }
+
+    public function testDeleteEntityThrowsCouldNotDeleteExceptionOnFailure(): void
+    {
+        $this->expectException(CouldNotDeleteException::class);
+
+        $this->resourceModel->method('delete')
+            ->willThrowException(new \Exception('constraint violation'));
+
+        $this->repository->delete($this->entity);
+    }
+
+    public function testDeleteEntityExceptionMessageIncludesEntityLabelAndOriginalMessage(): void
+    {
+        $this->resourceModel->method('delete')
+            ->willThrowException(new \Exception('foreign key constraint'));
+
+        try {
+            $this->repository->delete($this->entity);
+            $this->fail('Expected CouldNotDeleteException');
+        } catch (CouldNotDeleteException $e) {
+            $this->assertStringContainsString('widget', $e->getMessage());
+            $this->assertStringContainsString('foreign key constraint', $e->getMessage());
+        }
+    }
+
+    public function testDeleteEntityWrapsOriginalExceptionAsPrevious(): void
+    {
+        $original = new \Exception('original error');
+        $this->resourceModel->method('delete')->willThrowException($original);
+
+        try {
+            $this->repository->delete($this->entity);
+        } catch (CouldNotDeleteException $e) {
+            $this->assertSame($original, $e->getPrevious());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // performGetList
+    // -------------------------------------------------------------------------
+
+    public function testPerformGetListAppliesSearchCriteriaToCollection(): void
+    {
+        $searchCriteria = $this->createMock(SearchCriteriaInterface::class);
+
+        $this->collectionProcessor->expects($this->once())
+            ->method('process')
+            ->with($searchCriteria, $this->collection);
+
+        $this->searchResults->method('setSearchCriteria')->willReturnSelf();
+        $this->searchResults->method('setItems')->willReturnSelf();
+        $this->searchResults->method('setTotalCount')->willReturnSelf();
+        $this->collection->method('getItems')->willReturn([]);
+        $this->collection->method('getSize')->willReturn(0);
+
+        $this->repository->getList($searchCriteria);
+    }
+
+    public function testPerformGetListSetsItemsOnSearchResults(): void
+    {
+        $searchCriteria = $this->createMock(SearchCriteriaInterface::class);
+        $items = [$this->createMock(AbstractModel::class)];
+
+        $this->collection->method('getItems')->willReturn($items);
+        $this->collection->method('getSize')->willReturn(1);
+
+        $this->searchResults->method('setSearchCriteria')->willReturnSelf();
+        $this->searchResults->method('setTotalCount')->willReturnSelf();
+        $this->searchResults->expects($this->once())
+            ->method('setItems')
+            ->with($items)
+            ->willReturnSelf();
+
+        $this->repository->getList($searchCriteria);
+    }
+
+    public function testPerformGetListSetsTotalCountOnSearchResults(): void
+    {
+        $searchCriteria = $this->createMock(SearchCriteriaInterface::class);
+
+        $this->collection->method('getItems')->willReturn([]);
+        $this->collection->method('getSize')->willReturn(42);
+
+        $this->searchResults->method('setSearchCriteria')->willReturnSelf();
+        $this->searchResults->method('setItems')->willReturnSelf();
+        $this->searchResults->expects($this->once())
+            ->method('setTotalCount')
+            ->with(42)
+            ->willReturnSelf();
+
+        $this->repository->getList($searchCriteria);
+    }
+
+    public function testPerformGetListSetsSearchCriteriaOnResults(): void
+    {
+        $searchCriteria = $this->createMock(SearchCriteriaInterface::class);
+
+        $this->collection->method('getItems')->willReturn([]);
+        $this->collection->method('getSize')->willReturn(0);
+
+        $this->searchResults->method('setItems')->willReturnSelf();
+        $this->searchResults->method('setTotalCount')->willReturnSelf();
+        $this->searchResults->expects($this->once())
+            ->method('setSearchCriteria')
+            ->with($searchCriteria)
+            ->willReturnSelf();
+
+        $this->repository->getList($searchCriteria);
+    }
+
+    public function testPerformGetListReturnsSearchResults(): void
+    {
+        $searchCriteria = $this->createMock(SearchCriteriaInterface::class);
+
+        $this->collection->method('getItems')->willReturn([]);
+        $this->collection->method('getSize')->willReturn(0);
+        $this->searchResults->method('setSearchCriteria')->willReturnSelf();
+        $this->searchResults->method('setItems')->willReturnSelf();
+        $this->searchResults->method('setTotalCount')->willReturnSelf();
+
+        $result = $this->repository->getList($searchCriteria);
+
+        $this->assertSame($this->searchResults, $result);
+    }
+}

--- a/Test/Unit/Model/RMA/StatusResolverTest.php
+++ b/Test/Unit/Model/RMA/StatusResolverTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MageOS\RMA\Test\Unit\Model\RMA;
+
+use MageOS\RMA\Api\Data\StatusInterface;
+use MageOS\RMA\Api\Data\StatusSearchResultsInterface;
+use MageOS\RMA\Api\StatusRepositoryInterface;
+use MageOS\RMA\Model\RMA\StatusResolver;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteriaBuilderFactory;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class StatusResolverTest extends TestCase
+{
+    private StatusRepositoryInterface&MockObject $statusRepository;
+    private SearchCriteriaBuilderFactory&MockObject $searchCriteriaBuilderFactory;
+    private SearchCriteriaBuilder&MockObject $searchCriteriaBuilder;
+    private StatusResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->statusRepository = $this->createMock(StatusRepositoryInterface::class);
+        $this->searchCriteriaBuilderFactory = $this->createMock(SearchCriteriaBuilderFactory::class);
+        $this->searchCriteriaBuilder = $this->createMock(SearchCriteriaBuilder::class);
+
+        $this->searchCriteriaBuilderFactory->method('create')->willReturn($this->searchCriteriaBuilder);
+
+        $this->resolver = new StatusResolver(
+            $this->statusRepository,
+            $this->searchCriteriaBuilderFactory
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // getCodeById
+    // -------------------------------------------------------------------------
+
+    public function testGetCodeByIdFetchesFromRepositoryOnCacheMiss(): void
+    {
+        $status = $this->createMock(StatusInterface::class);
+        $status->method('getCode')->willReturn('approved');
+
+        $this->statusRepository->expects($this->once())->method('get')->with(1)->willReturn($status);
+
+        $result = $this->resolver->getCodeById(1);
+
+        $this->assertSame('approved', $result);
+    }
+
+    public function testGetCodeByIdReturnsCachedValueWithoutRepositoryCall(): void
+    {
+        $status = $this->createMock(StatusInterface::class);
+        $status->method('getCode')->willReturn('approved');
+
+        $this->statusRepository->expects($this->once())->method('get')->willReturn($status);
+
+        $this->resolver->getCodeById(1);
+        $result = $this->resolver->getCodeById(1);
+
+        $this->assertSame('approved', $result);
+    }
+
+    public function testGetCodeByIdReturnsNullWhenStatusNotFound(): void
+    {
+        $this->statusRepository->method('get')
+            ->willThrowException(new NoSuchEntityException(__('Not found')));
+
+        $result = $this->resolver->getCodeById(999);
+
+        $this->assertNull($result);
+    }
+
+    // -------------------------------------------------------------------------
+    // getIdByCode
+    // -------------------------------------------------------------------------
+
+    public function testGetIdByCodeFetchesFromRepository(): void
+    {
+        $searchCriteria = $this->createMock(SearchCriteriaInterface::class);
+        $this->searchCriteriaBuilder->method('addFilter')->willReturnSelf();
+        $this->searchCriteriaBuilder->method('create')->willReturn($searchCriteria);
+
+        $status = $this->createMock(StatusInterface::class);
+        $status->method('getEntityId')->willReturn(3);
+        $status->method('getCode')->willReturn('rejected');
+
+        $searchResults = $this->createMock(StatusSearchResultsInterface::class);
+        $searchResults->method('getItems')->willReturn([$status]);
+
+        $this->statusRepository->method('getList')->willReturn($searchResults);
+
+        $result = $this->resolver->getIdByCode('rejected');
+
+        $this->assertSame(3, $result);
+    }
+
+    public function testGetIdByCodeReturnsCachedValueWithoutRepositoryCall(): void
+    {
+        $searchCriteria = $this->createMock(SearchCriteriaInterface::class);
+        $this->searchCriteriaBuilder->method('addFilter')->willReturnSelf();
+        $this->searchCriteriaBuilder->method('create')->willReturn($searchCriteria);
+
+        $status = $this->createMock(StatusInterface::class);
+        $status->method('getEntityId')->willReturn(3);
+        $status->method('getCode')->willReturn('rejected');
+
+        $searchResults = $this->createMock(StatusSearchResultsInterface::class);
+        $searchResults->method('getItems')->willReturn([$status]);
+
+        $this->statusRepository->expects($this->once())->method('getList')->willReturn($searchResults);
+
+        $this->resolver->getIdByCode('rejected');
+        $result = $this->resolver->getIdByCode('rejected');
+
+        $this->assertSame(3, $result);
+    }
+
+    public function testGetIdByCodeReturnsNullWhenNotFound(): void
+    {
+        $searchCriteria = $this->createMock(SearchCriteriaInterface::class);
+        $this->searchCriteriaBuilder->method('addFilter')->willReturnSelf();
+        $this->searchCriteriaBuilder->method('create')->willReturn($searchCriteria);
+
+        $searchResults = $this->createMock(StatusSearchResultsInterface::class);
+        $searchResults->method('getItems')->willReturn([]);
+
+        $this->statusRepository->method('getList')->willReturn($searchResults);
+
+        $result = $this->resolver->getIdByCode('nonexistent_code');
+
+        $this->assertNull($result);
+    }
+
+    public function testGetIdByCodeUsesFlippedCacheFromPriorGetCodeByIdCall(): void
+    {
+        $status = $this->createMock(StatusInterface::class);
+        $status->method('getCode')->willReturn('approved');
+
+        $this->statusRepository->expects($this->once())->method('get')->with(2)->willReturn($status);
+        $this->statusRepository->expects($this->never())->method('getList');
+
+        $this->resolver->getCodeById(2);
+
+        $result = $this->resolver->getIdByCode('approved');
+
+        $this->assertSame(2, $result);
+    }
+}

--- a/Test/Unit/Model/RMARepositoryTest.php
+++ b/Test/Unit/Model/RMARepositoryTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MageOS\RMA\Test\Unit\Model;
+
+use MageOS\RMA\Api\Data\RMAInterface;
+use MageOS\RMA\Api\Data\RMASearchResultsInterface;
+use MageOS\RMA\Model\RMA;
+use MageOS\RMA\Api\Data\RMASearchResultsInterfaceFactory;
+use MageOS\RMA\Model\RMA\StatusCodes;
+use MageOS\RMA\Model\RMA\StatusResolver;
+use MageOS\RMA\Model\RMAFactory;
+use MageOS\RMA\Model\RMARepository;
+use MageOS\RMA\Model\ResourceModel\RMA as ResourceModel;
+use MageOS\RMA\Model\ResourceModel\RMA\CollectionFactory;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Event\ManagerInterface as EventManagerInterface;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class RMARepositoryTest extends TestCase
+{
+    private ResourceModel&MockObject $resourceModel;
+    private RMAFactory&MockObject $rmaFactory;
+    private CollectionFactory&MockObject $collectionFactory;
+    private RMASearchResultsInterfaceFactory&MockObject $searchResultsFactory;
+    private CollectionProcessorInterface&MockObject $collectionProcessor;
+    private EventManagerInterface&MockObject $eventManager;
+    private StatusResolver&MockObject $statusResolver;
+    private AdapterInterface&MockObject $connection;
+    private Select&MockObject $select;
+    private RMARepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->resourceModel      = $this->createMock(ResourceModel::class);
+        $this->rmaFactory         = $this->createMock(RMAFactory::class);
+        $this->collectionFactory  = $this->createMock(CollectionFactory::class);
+        $this->searchResultsFactory = $this->createMock(RMASearchResultsInterfaceFactory::class);
+        $this->collectionProcessor  = $this->createMock(CollectionProcessorInterface::class);
+        $this->eventManager       = $this->createMock(EventManagerInterface::class);
+        $this->statusResolver     = $this->createMock(StatusResolver::class);
+        $this->connection         = $this->createMock(AdapterInterface::class);
+        $this->select             = $this->createMock(Select::class);
+
+        $this->select->method('from')->willReturnSelf();
+        $this->select->method('where')->willReturnSelf();
+        $this->connection->method('select')->willReturn($this->select);
+        $this->resourceModel->method('getConnection')->willReturn($this->connection);
+        $this->resourceModel->method('getMainTable')->willReturn('rma_entity');
+
+        $this->repository = new RMARepository(
+            $this->resourceModel,
+            $this->rmaFactory,
+            $this->collectionFactory,
+            $this->searchResultsFactory,
+            $this->collectionProcessor,
+            $this->eventManager,
+            $this->statusResolver
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // get
+    // -------------------------------------------------------------------------
+
+    public function testGetReturnsRmaWhenFound(): void
+    {
+        $rma = $this->createMock(RMA::class);
+        $rma->method('getEntityId')->willReturn(1);
+
+        $this->rmaFactory->method('create')->willReturn($rma);
+
+        $result = $this->repository->get(1);
+
+        $this->assertSame($rma, $result);
+    }
+
+    public function testGetThrowsNoSuchEntityExceptionWhenNotFound(): void
+    {
+        $this->expectException(NoSuchEntityException::class);
+
+        $rma = $this->createMock(RMA::class);
+        $rma->method('getEntityId')->willReturn(null);
+
+        $this->rmaFactory->method('create')->willReturn($rma);
+
+        $this->repository->get(999);
+    }
+
+    // -------------------------------------------------------------------------
+    // save — exception wrapping
+    // -------------------------------------------------------------------------
+
+    public function testSaveThrowsCouldNotSaveExceptionOnResourceModelFailure(): void
+    {
+        $this->expectException(CouldNotSaveException::class);
+
+        $rma = $this->createMock(RMA::class);
+        $rma->method('getEntityId')->willReturn(null);
+
+        $this->resourceModel->method('save')->willThrowException(new \Exception('DB error'));
+
+        $this->repository->save($rma);
+    }
+
+    // -------------------------------------------------------------------------
+    // delete — exception wrapping
+    // -------------------------------------------------------------------------
+
+    public function testDeleteThrowsCouldNotDeleteExceptionOnResourceModelFailure(): void
+    {
+        $this->expectException(CouldNotDeleteException::class);
+
+        $rma = $this->createMock(RMA::class);
+        $this->resourceModel->method('delete')->willThrowException(new \Exception('DB error'));
+
+        $this->repository->delete($rma);
+    }
+
+    public function testDeleteReturnsTrueOnSuccess(): void
+    {
+        $rma = $this->createMock(RMA::class);
+
+        $this->assertTrue($this->repository->delete($rma));
+    }
+
+    // -------------------------------------------------------------------------
+    // dispatchEvents — new RMA
+    // -------------------------------------------------------------------------
+
+    public function testSaveDispatchesCreatedEventForNewRma(): void
+    {
+        $rma = $this->createMock(RMA::class);
+        $rma->method('getEntityId')->willReturn(null);
+
+        $this->eventManager->expects($this->once())
+            ->method('dispatch')
+            ->with('rma_created_after', ['rma' => $rma]);
+
+        $this->repository->save($rma);
+    }
+
+    public function testSaveDoesNotDispatchStatusChangeEventForNewRma(): void
+    {
+        $rma = $this->createMock(RMA::class);
+        $rma->method('getEntityId')->willReturn(null);
+
+        $this->eventManager->expects($this->once())
+            ->method('dispatch')
+            ->with('rma_created_after', $this->anything());
+
+        $this->repository->save($rma);
+    }
+
+    // -------------------------------------------------------------------------
+    // dispatchEvents — existing RMA, status unchanged
+    // -------------------------------------------------------------------------
+
+    public function testSaveDispatchesNoEventsWhenStatusUnchanged(): void
+    {
+        $rma = $this->createMock(RMA::class);
+        $rma->method('getEntityId')->willReturn(10);
+        $rma->method('getStatusId')->willReturn(2);
+
+        $this->connection->method('fetchOne')->willReturn('2');
+
+        $this->eventManager->expects($this->never())->method('dispatch');
+
+        $this->repository->save($rma);
+    }
+
+    // -------------------------------------------------------------------------
+    // dispatchEvents — existing RMA, status changed
+    // -------------------------------------------------------------------------
+
+    public function testSaveDispatchesStatusChangeEventWhenStatusChanges(): void
+    {
+        $rma = $this->createMock(RMA::class);
+        $rma->method('getEntityId')->willReturn(10);
+        $rma->method('getStatusId')->willReturn(3);
+
+        $this->connection->method('fetchOne')->willReturn('2');
+        $this->statusResolver->method('getCodeById')->with(3)->willReturn('need_details');
+
+        $this->eventManager->expects($this->once())
+            ->method('dispatch')
+            ->with('rma_status_change_after', [
+                'rma'           => $rma,
+                'old_status_id' => 2,
+                'new_status_id' => 3,
+            ]);
+
+        $this->repository->save($rma);
+    }
+
+    // -------------------------------------------------------------------------
+    // dispatchSemanticStatusEvent
+    // -------------------------------------------------------------------------
+
+    /**
+     * @dataProvider semanticStatusEventProvider
+     */
+    public function testSaveDispatchesSemanticEventForKnownStatusCode(
+        string $statusCode,
+        string $expectedEvent
+    ): void {
+        $rma = $this->createMock(RMA::class);
+        $rma->method('getEntityId')->willReturn(10);
+        $rma->method('getStatusId')->willReturn(5);
+
+        $this->connection->method('fetchOne')->willReturn('1');
+        $this->statusResolver->method('getCodeById')->with(5)->willReturn($statusCode);
+
+        $dispatched = [];
+        $this->eventManager->method('dispatch')
+            ->willReturnCallback(function (string $name, array $data) use (&$dispatched): void {
+                $dispatched[] = $name;
+            });
+
+        $this->repository->save($rma);
+
+        $this->assertContains('rma_status_change_after', $dispatched);
+        $this->assertContains($expectedEvent, $dispatched);
+    }
+
+    public static function semanticStatusEventProvider(): array
+    {
+        return [
+            'approved'             => [StatusCodes::APPROVED,             'rma_approved_after'],
+            'rejected'             => [StatusCodes::REJECTED,             'rma_rejected_after'],
+            'shipped_by_customer'  => [StatusCodes::SHIPPED_BY_CUSTOMER,  'rma_shipped_by_customer_after'],
+            'received_by_admin'    => [StatusCodes::RECEIVED_BY_ADMIN,    'rma_received_after'],
+            'canceled_by_customer' => [StatusCodes::CANCELED_BY_CUSTOMER, 'rma_canceled_after'],
+            'resolved'             => [StatusCodes::RESOLVED,             'rma_resolved_after'],
+        ];
+    }
+
+    public function testSaveDoesNotDispatchSemanticEventForCodeNotInMap(): void
+    {
+        $rma = $this->createMock(RMA::class);
+        $rma->method('getEntityId')->willReturn(10);
+        $rma->method('getStatusId')->willReturn(5);
+
+        $this->connection->method('fetchOne')->willReturn('1');
+        // need_details is not in STATUS_EVENT_MAP
+        $this->statusResolver->method('getCodeById')->willReturn(StatusCodes::NEED_DETAILS);
+
+        $dispatched = [];
+        $this->eventManager->method('dispatch')
+            ->willReturnCallback(function (string $name) use (&$dispatched): void {
+                $dispatched[] = $name;
+            });
+
+        $this->repository->save($rma);
+
+        $this->assertContains('rma_status_change_after', $dispatched);
+        $this->assertCount(1, $dispatched);
+    }
+
+    public function testSaveDoesNotDispatchSemanticEventWhenStatusCodeIsNull(): void
+    {
+        $rma = $this->createMock(RMA::class);
+        $rma->method('getEntityId')->willReturn(10);
+        $rma->method('getStatusId')->willReturn(5);
+
+        $this->connection->method('fetchOne')->willReturn('1');
+        $this->statusResolver->method('getCodeById')->willReturn(null);
+
+        $dispatched = [];
+        $this->eventManager->method('dispatch')
+            ->willReturnCallback(function (string $name) use (&$dispatched): void {
+                $dispatched[] = $name;
+            });
+
+        $this->repository->save($rma);
+
+        $this->assertContains('rma_status_change_after', $dispatched);
+        $this->assertCount(1, $dispatched);
+    }
+}

--- a/Test/Unit/Service/AttachmentServiceTest.php
+++ b/Test/Unit/Service/AttachmentServiceTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MageOS\RMA\Test\Unit\Service;
+
+use MageOS\RMA\Api\AttachmentRepositoryInterface;
+use MageOS\RMA\Api\Data\AttachmentInterface;
+use MageOS\RMA\Api\Data\AttachmentInterfaceFactory;
+use MageOS\RMA\Helper\ModuleConfig;
+use MageOS\RMA\Model\ResourceModel\Attachment\CollectionFactory as AttachmentCollectionFactory;
+use MageOS\RMA\Service\AttachmentService;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\File\Mime;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\WriteInterface;
+use Magento\Framework\Serialize\Serializer\Json as JsonSerializer;
+use Magento\MediaStorage\Model\File\UploaderFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class AttachmentServiceTest extends TestCase
+{
+    private WriteInterface&MockObject $varDirectory;
+    private AttachmentService $service;
+
+    protected function setUp(): void
+    {
+        $this->varDirectory = $this->createMock(WriteInterface::class);
+
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('getDirectoryWrite')->willReturn($this->varDirectory);
+
+        $this->service = new AttachmentService(
+            $filesystem,
+            $this->createMock(UploaderFactory::class),
+            $this->createMock(ModuleConfig::class),
+            $this->createMock(AttachmentInterfaceFactory::class),
+            $this->createMock(AttachmentRepositoryInterface::class),
+            $this->createMock(AttachmentCollectionFactory::class),
+            $this->createMock(Mime::class),
+            $this->createMock(JsonSerializer::class)
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // getAbsolutePath — path traversal guard
+    // -------------------------------------------------------------------------
+
+    public function testGetAbsolutePathReturnsResolvedPathForValidFile(): void
+    {
+        $attachment = $this->createMock(AttachmentInterface::class);
+        $attachment->method('getFilePath')->willReturn('rma/attachments/42/receipt.pdf');
+
+        $this->varDirectory->method('getAbsolutePath')
+            ->willReturnMap([
+                ['rma/attachments/42/receipt.pdf', '/var/www/html/var/rma/attachments/42/receipt.pdf'],
+                [AttachmentService::BASE_PATH,      '/var/www/html/var/rma/attachments'],
+            ]);
+
+        $result = $this->service->getAbsolutePath($attachment);
+
+        $this->assertSame('/var/www/html/var/rma/attachments/42/receipt.pdf', $result);
+    }
+
+    public function testGetAbsolutePathThrowsOnPathTraversalAttempt(): void
+    {
+        $this->expectException(LocalizedException::class);
+
+        $attachment = $this->createMock(AttachmentInterface::class);
+        $attachment->method('getFilePath')->willReturn('rma/attachments/../../etc/passwd');
+
+        $this->varDirectory->method('getAbsolutePath')
+            ->willReturnMap([
+                ['rma/attachments/../../etc/passwd', '/var/www/html/var/etc/passwd'],
+                [AttachmentService::BASE_PATH,        '/var/www/html/var/rma/attachments'],
+            ]);
+
+        $this->service->getAbsolutePath($attachment);
+    }
+
+    public function testGetAbsolutePathThrowsWhenPathIsOutsideBaseDir(): void
+    {
+        $this->expectException(LocalizedException::class);
+
+        $attachment = $this->createMock(AttachmentInterface::class);
+        $attachment->method('getFilePath')->willReturn('rma/tmp/malicious.php');
+
+        $this->varDirectory->method('getAbsolutePath')
+            ->willReturnMap([
+                ['rma/tmp/malicious.php',      '/var/www/html/var/rma/tmp/malicious.php'],
+                [AttachmentService::BASE_PATH,  '/var/www/html/var/rma/attachments'],
+            ]);
+
+        $this->service->getAbsolutePath($attachment);
+    }
+
+    public function testGetAbsolutePathThrowsWhenPathMatchesPrefixButIsNotChild(): void
+    {
+        $this->expectException(LocalizedException::class);
+
+        // Without the trailing-slash guard, str_starts_with('/var/.../rma/attachments-evil/...', '/var/.../rma/attachments')
+        // would return TRUE and allow the path through. The fix normalises basePath to end with '/'.
+        $attachment = $this->createMock(AttachmentInterface::class);
+        $attachment->method('getFilePath')->willReturn('rma/attachments-evil/file.php');
+
+        $this->varDirectory->method('getAbsolutePath')
+            ->willReturnMap([
+                ['rma/attachments-evil/file.php', '/var/www/html/var/rma/attachments-evil/file.php'],
+                [AttachmentService::BASE_PATH,     '/var/www/html/var/rma/attachments'],
+            ]);
+
+        $this->service->getAbsolutePath($attachment);
+    }
+
+    // -------------------------------------------------------------------------
+    // formatFileSize
+    // -------------------------------------------------------------------------
+
+    /**
+     * @dataProvider fileSizeProvider
+     */
+    public function testFormatFileSize(int $bytes, string $expected): void
+    {
+        $this->assertSame($expected, $this->service->formatFileSize($bytes));
+    }
+
+    public static function fileSizeProvider(): array
+    {
+        return [
+            'bytes'      => [512,           '512 B'],
+            'exactly 1KB'=> [1024,          '1 KB'],
+            'kilobytes'  => [2048,          '2 KB'],
+            'megabytes'  => [1048576,       '1 MB'],
+            'fractional' => [1572864,       '1.5 MB'],
+            'zero bytes' => [0,             '0 B'],
+        ];
+    }
+}

--- a/Test/Unit/Service/AttachmentUploadTest.php
+++ b/Test/Unit/Service/AttachmentUploadTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MageOS\RMA\Test\Unit\Service;
+
+use MageOS\RMA\Api\AttachmentRepositoryInterface;
+use MageOS\RMA\Api\Data\AttachmentInterfaceFactory;
+use MageOS\RMA\Helper\ModuleConfig;
+use MageOS\RMA\Model\Config\Source\AllowedExtensions;
+use MageOS\RMA\Model\ResourceModel\Attachment\CollectionFactory as AttachmentCollectionFactory;
+use MageOS\RMA\Service\AttachmentService;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\File\Mime;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\WriteInterface;
+use Magento\Framework\Serialize\Serializer\Json as JsonSerializer;
+use Magento\MediaStorage\Model\File\Uploader;
+use Magento\MediaStorage\Model\File\UploaderFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class AttachmentUploadTest extends TestCase
+{
+    private WriteInterface&MockObject $varDirectory;
+    private UploaderFactory&MockObject $uploaderFactory;
+    private ModuleConfig&MockObject $moduleConfig;
+    private AttachmentService $service;
+
+    protected function setUp(): void
+    {
+        $this->varDirectory    = $this->createMock(WriteInterface::class);
+        $this->uploaderFactory = $this->createMock(UploaderFactory::class);
+        $this->moduleConfig    = $this->createMock(ModuleConfig::class);
+
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('getDirectoryWrite')->willReturn($this->varDirectory);
+
+        $this->service = new AttachmentService(
+            $filesystem,
+            $this->uploaderFactory,
+            $this->moduleConfig,
+            $this->createMock(AttachmentInterfaceFactory::class),
+            $this->createMock(AttachmentRepositoryInterface::class),
+            $this->createMock(AttachmentCollectionFactory::class),
+            $this->createMock(Mime::class),
+            $this->createMock(JsonSerializer::class)
+        );
+    }
+
+    private function makeUploader(): Uploader&MockObject
+    {
+        $uploader = $this->createMock(Uploader::class);
+        $uploader->method('setAllowedExtensions')->willReturnSelf();
+        $uploader->method('setAllowRenameFiles')->willReturnSelf();
+        $uploader->method('setFilesDispersion')->willReturnSelf();
+
+        return $uploader;
+    }
+
+    // -------------------------------------------------------------------------
+    // Pre-flight size check (before upload)
+    // -------------------------------------------------------------------------
+
+    public function testUploadToTmpThrowsWhenPreflightFileSizeExceedsLimit(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessageMatches('/maximum allowed size/');
+
+        $this->moduleConfig->method('getMaxAttachmentFileSizeBytes')->willReturn(1024);
+        $this->moduleConfig->method('getMaxAttachmentFileSize')->willReturn(1);
+
+        $_FILES['rma_file'] = ['size' => 2048];
+
+        $this->uploaderFactory->expects($this->never())->method('create');
+
+        try {
+            $this->service->uploadToTmp('rma_file');
+        } finally {
+            unset($_FILES['rma_file']);
+        }
+    }
+
+    public function testUploadToTmpDoesNotThrowWhenFileSizeIsWithinLimit(): void
+    {
+        $this->moduleConfig->method('getMaxAttachmentFileSizeBytes')->willReturn(1024);
+        $this->moduleConfig->method('getMaxAttachmentFileSize')->willReturn(1);
+        $this->moduleConfig->method('getAllowedAttachmentExtensions')->willReturn(['jpg']);
+
+        $_FILES['rma_file'] = ['size' => 512];
+
+        $uploader = $this->makeUploader();
+        $uploader->method('checkMimeType')->willReturn(false);
+
+        $this->uploaderFactory->method('create')->willReturn($uploader);
+        $this->varDirectory->method('getAbsolutePath')->willReturn('/var/www/html/var/rma/tmp');
+
+        try {
+            $this->service->uploadToTmp('rma_file');
+        } catch (LocalizedException $e) {
+            $this->assertStringContainsString('File type not allowed', $e->getMessage());
+        } finally {
+            unset($_FILES['rma_file']);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // MIME type validation
+    // -------------------------------------------------------------------------
+
+    public function testUploadToTmpThrowsWhenMimeTypeNotAllowed(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessageMatches('/File type not allowed/');
+
+        $this->moduleConfig->method('getMaxAttachmentFileSizeBytes')->willReturn(10 * 1024 * 1024);
+        $this->moduleConfig->method('getAllowedAttachmentExtensions')->willReturn(['jpg', 'png']);
+
+        $uploader = $this->makeUploader();
+        $uploader->method('checkMimeType')->willReturn(false);
+
+        $this->uploaderFactory->method('create')->willReturn($uploader);
+        $this->varDirectory->method('getAbsolutePath')->willReturn('/var/www/html/var/rma/tmp');
+
+        $this->service->uploadToTmp('rma_file');
+    }
+
+    public function testUploadToTmpPassesCorrectMimeTypesForConfiguredExtensions(): void
+    {
+        $this->moduleConfig->method('getMaxAttachmentFileSizeBytes')->willReturn(10 * 1024 * 1024);
+        $this->moduleConfig->method('getAllowedAttachmentExtensions')->willReturn(['jpg', 'pdf']);
+
+        $expectedMimeTypes = array_unique(array_merge(
+            AllowedExtensions::EXTENSION_MIME_MAP['jpg'],
+            AllowedExtensions::EXTENSION_MIME_MAP['pdf']
+        ));
+
+        $uploader = $this->makeUploader();
+        $uploader->expects($this->once())
+            ->method('checkMimeType')
+            ->with($expectedMimeTypes)
+            ->willReturn(false);
+
+        $this->uploaderFactory->method('create')->willReturn($uploader);
+        $this->varDirectory->method('getAbsolutePath')->willReturn('/var/www/html/var/rma/tmp');
+
+        try {
+            $this->service->uploadToTmp('rma_file');
+        } catch (LocalizedException) {
+            // expected — we only care that checkMimeType was called with the right types
+        }
+    }
+
+    public function testUploadToTmpExcludesMimeTypesForUnconfiguredExtensions(): void
+    {
+        $this->moduleConfig->method('getMaxAttachmentFileSizeBytes')->willReturn(10 * 1024 * 1024);
+        // Only jpg configured — zip should not appear in the allowed MIME list
+        $this->moduleConfig->method('getAllowedAttachmentExtensions')->willReturn(['jpg']);
+
+        $uploader = $this->makeUploader();
+        $uploader->expects($this->once())
+            ->method('checkMimeType')
+            ->with($this->callback(function (array $mimeTypes): bool {
+                return !in_array('application/zip', $mimeTypes, true)
+                    && !in_array('application/x-zip-compressed', $mimeTypes, true);
+            }))
+            ->willReturn(false);
+
+        $this->uploaderFactory->method('create')->willReturn($uploader);
+        $this->varDirectory->method('getAbsolutePath')->willReturn('/var/www/html/var/rma/tmp');
+
+        try {
+            $this->service->uploadToTmp('rma_file');
+        } catch (LocalizedException) {
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Extension allowlist is wired to uploader
+    // -------------------------------------------------------------------------
+
+    public function testUploadToTmpPassesAllowedExtensionsToUploader(): void
+    {
+        $allowedExtensions = ['jpg', 'png', 'pdf'];
+
+        $this->moduleConfig->method('getMaxAttachmentFileSizeBytes')->willReturn(10 * 1024 * 1024);
+        $this->moduleConfig->method('getAllowedAttachmentExtensions')->willReturn($allowedExtensions);
+
+        $uploader = $this->makeUploader();
+        $uploader->expects($this->once())
+            ->method('setAllowedExtensions')
+            ->with($allowedExtensions);
+        $uploader->method('checkMimeType')->willReturn(false);
+
+        $this->uploaderFactory->method('create')->willReturn($uploader);
+        $this->varDirectory->method('getAbsolutePath')->willReturn('/var/www/html/var/rma/tmp');
+
+        try {
+            $this->service->uploadToTmp('rma_file');
+        } catch (LocalizedException) {
+        }
+    }
+
+    public function testUploadToTmpPassesEmptyExtensionListWhenNoneConfigured(): void
+    {
+        $this->moduleConfig->method('getMaxAttachmentFileSizeBytes')->willReturn(10 * 1024 * 1024);
+        $this->moduleConfig->method('getAllowedAttachmentExtensions')->willReturn([]);
+
+        $uploader = $this->makeUploader();
+        $uploader->expects($this->once())
+            ->method('setAllowedExtensions')
+            ->with([]);
+        $uploader->method('checkMimeType')->willReturn(false);
+
+        $this->uploaderFactory->method('create')->willReturn($uploader);
+        $this->varDirectory->method('getAbsolutePath')->willReturn('/var/www/html/var/rma/tmp');
+
+        try {
+            $this->service->uploadToTmp('rma_file');
+        } catch (LocalizedException) {
+        }
+    }
+}

--- a/Test/Unit/Service/OrderEligibilityTest.php
+++ b/Test/Unit/Service/OrderEligibilityTest.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MageOS\RMA\Test\Unit\Service;
+
+use MageOS\RMA\Helper\ModuleConfig;
+use MageOS\RMA\Model\ResourceModel\Item\CollectionFactory as RmaItemCollectionFactory;
+use MageOS\RMA\Service\OrderEligibility;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\Data\OrderItemInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\ResourceModel\Order\CollectionFactory as OrderCollectionFactory;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class OrderEligibilityTest extends TestCase
+{
+    private ModuleConfig&MockObject $moduleConfig;
+    private RmaItemCollectionFactory&MockObject $rmaItemCollectionFactory;
+    private OrderCollectionFactory&MockObject $orderCollectionFactory;
+    private OrderRepositoryInterface&MockObject $orderRepository;
+    private TimezoneInterface&MockObject $timezone;
+    private StoreManagerInterface&MockObject $storeManager;
+
+    protected function setUp(): void
+    {
+        $this->moduleConfig = $this->createMock(ModuleConfig::class);
+        $this->rmaItemCollectionFactory = $this->createMock(RmaItemCollectionFactory::class);
+        $this->orderCollectionFactory = $this->createMock(OrderCollectionFactory::class);
+        $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
+        $this->timezone = $this->createMock(TimezoneInterface::class);
+        $this->storeManager = $this->createMock(StoreManagerInterface::class);
+    }
+
+    private function createService(array $stubbedMethods = []): OrderEligibility
+    {
+        if (empty($stubbedMethods)) {
+            return new OrderEligibility(
+                $this->moduleConfig,
+                $this->rmaItemCollectionFactory,
+                $this->orderCollectionFactory,
+                $this->orderRepository,
+                $this->timezone,
+                $this->storeManager
+            );
+        }
+
+        return $this->getMockBuilder(OrderEligibility::class)
+            ->setConstructorArgs([
+                $this->moduleConfig,
+                $this->rmaItemCollectionFactory,
+                $this->orderCollectionFactory,
+                $this->orderRepository,
+                $this->timezone,
+                $this->storeManager,
+            ])
+            ->onlyMethods($stubbedMethods)
+            ->getMock();
+    }
+
+    private function createOrder(int $storeId = 1, string $status = 'complete', string $createdAt = ''): OrderInterface&MockObject
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getStoreId')->willReturn($storeId);
+        $order->method('getStatus')->willReturn($status);
+        $order->method('getCreatedAt')->willReturn($createdAt ?: date('Y-m-d H:i:s'));
+        $order->method('getEntityId')->willReturn(100);
+
+        return $order;
+    }
+
+    // -------------------------------------------------------------------------
+    // isOrderEligible
+    // -------------------------------------------------------------------------
+
+    public function testIsOrderEligibleReturnsFalseWhenModuleDisabled(): void
+    {
+        $this->moduleConfig->method('isEnabled')->with(1)->willReturn(false);
+        $service = $this->createService(['getEligibleItems']);
+
+        $this->assertFalse($service->isOrderEligible($this->createOrder()));
+    }
+
+    public function testIsOrderEligibleReturnsFalseWhenStatusNotAllowed(): void
+    {
+        $this->moduleConfig->method('isEnabled')->willReturn(true);
+        $this->moduleConfig->method('getAllowedOrderStatuses')->willReturn(['complete']);
+
+        $order = $this->createOrder(status: 'pending');
+        $service = $this->createService(['getEligibleItems']);
+
+        $this->assertFalse($service->isOrderEligible($order));
+    }
+
+    public function testIsOrderEligibleReturnsFalseWhenOutsideReturnPeriod(): void
+    {
+        $this->moduleConfig->method('isEnabled')->willReturn(true);
+        $this->moduleConfig->method('getAllowedOrderStatuses')->willReturn(['complete']);
+        $this->moduleConfig->method('getReturnPeriod')->willReturn(30);
+
+        $order = $this->createOrder(status: 'complete', createdAt: '2020-01-01 00:00:00');
+        $service = $this->createService(['getEligibleItems']);
+
+        $this->assertFalse($service->isOrderEligible($order));
+    }
+
+    public function testIsOrderEligibleReturnsFalseWhenNoEligibleItems(): void
+    {
+        $this->moduleConfig->method('isEnabled')->willReturn(true);
+        $this->moduleConfig->method('getAllowedOrderStatuses')->willReturn(['complete']);
+        $this->moduleConfig->method('getReturnPeriod')->willReturn(0);
+
+        $order = $this->createOrder(status: 'complete');
+
+        /** @var OrderEligibility&MockObject $service */
+        $service = $this->createService(['getEligibleItems']);
+        $service->method('getEligibleItems')->with($order)->willReturn([]);
+
+        $this->assertFalse($service->isOrderEligible($order));
+    }
+
+    public function testIsOrderEligibleReturnsTrueWhenAllConditionsMet(): void
+    {
+        $this->moduleConfig->method('isEnabled')->willReturn(true);
+        $this->moduleConfig->method('getAllowedOrderStatuses')->willReturn(['complete']);
+        $this->moduleConfig->method('getReturnPeriod')->willReturn(0);
+
+        $order = $this->createOrder(status: 'complete');
+
+        /** @var OrderEligibility&MockObject $service */
+        $service = $this->createService(['getEligibleItems']);
+        $service->method('getEligibleItems')->with($order)->willReturn([
+            ['order_item_id' => 1, 'name' => 'Product', 'sku' => 'SKU-1', 'qty_ordered' => 2, 'qty_already_requested' => 0, 'qty_available' => 2],
+        ]);
+
+        $this->assertTrue($service->isOrderEligible($order));
+    }
+
+    public function testIsOrderEligibleReturnsTrueWhenReturnPeriodIsUnlimited(): void
+    {
+        $this->moduleConfig->method('isEnabled')->willReturn(true);
+        $this->moduleConfig->method('getAllowedOrderStatuses')->willReturn(['complete']);
+        $this->moduleConfig->method('getReturnPeriod')->willReturn(0);
+
+        $order = $this->createOrder(status: 'complete', createdAt: '2010-01-01 00:00:00');
+
+        /** @var OrderEligibility&MockObject $service */
+        $service = $this->createService(['getEligibleItems']);
+        $service->method('getEligibleItems')->willReturn([['order_item_id' => 1]]);
+
+        $this->assertTrue($service->isOrderEligible($order));
+    }
+
+    // -------------------------------------------------------------------------
+    // getEligibleItems
+    // -------------------------------------------------------------------------
+
+    private function createOrderItem(
+        ?int $parentItemId,
+        string $productType,
+        int $itemId,
+        int $qtyOrdered,
+        string $name = 'Product',
+        string $sku = 'SKU-001'
+    ): OrderItemInterface&MockObject {
+        $item = $this->createMock(OrderItemInterface::class);
+        $item->method('getParentItemId')->willReturn($parentItemId);
+        $item->method('getProductType')->willReturn($productType);
+        $item->method('getItemId')->willReturn($itemId);
+        $item->method('getQtyOrdered')->willReturn($qtyOrdered);
+        $item->method('getName')->willReturn($name);
+        $item->method('getSku')->willReturn($sku);
+
+        return $item;
+    }
+
+    public function testGetEligibleItemsSkipsChildItems(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getEntityId')->willReturn(1);
+        $order->method('getItems')->willReturn([
+            $this->createOrderItem(parentItemId: 5, productType: 'simple', itemId: 10, qtyOrdered: 1),
+        ]);
+
+        /** @var OrderEligibility&MockObject $service */
+        $service = $this->createService(['getAlreadyRequestedQty']);
+        $service->method('getAlreadyRequestedQty')->willReturn([]);
+
+        $this->assertSame([], $service->getEligibleItems($order));
+    }
+
+    public function testGetEligibleItemsSkipsVirtualProducts(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getEntityId')->willReturn(1);
+        $order->method('getItems')->willReturn([
+            $this->createOrderItem(parentItemId: null, productType: 'virtual', itemId: 10, qtyOrdered: 1),
+        ]);
+
+        /** @var OrderEligibility&MockObject $service */
+        $service = $this->createService(['getAlreadyRequestedQty']);
+        $service->method('getAlreadyRequestedQty')->willReturn([]);
+
+        $this->assertSame([], $service->getEligibleItems($order));
+    }
+
+    public function testGetEligibleItemsSkipsDownloadableProducts(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getEntityId')->willReturn(1);
+        $order->method('getItems')->willReturn([
+            $this->createOrderItem(parentItemId: null, productType: 'downloadable', itemId: 10, qtyOrdered: 1),
+        ]);
+
+        /** @var OrderEligibility&MockObject $service */
+        $service = $this->createService(['getAlreadyRequestedQty']);
+        $service->method('getAlreadyRequestedQty')->willReturn([]);
+
+        $this->assertSame([], $service->getEligibleItems($order));
+    }
+
+    public function testGetEligibleItemsSkipsItemsWithNoAvailableQty(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getEntityId')->willReturn(1);
+        $order->method('getItems')->willReturn([
+            $this->createOrderItem(parentItemId: null, productType: 'simple', itemId: 10, qtyOrdered: 2),
+        ]);
+
+        /** @var OrderEligibility&MockObject $service */
+        $service = $this->createService(['getAlreadyRequestedQty']);
+        $service->method('getAlreadyRequestedQty')->willReturn([10 => 2]);
+
+        $this->assertSame([], $service->getEligibleItems($order));
+    }
+
+    public function testGetEligibleItemsDeductsAlreadyRequestedQty(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getEntityId')->willReturn(1);
+        $order->method('getItems')->willReturn([
+            $this->createOrderItem(parentItemId: null, productType: 'simple', itemId: 10, qtyOrdered: 3, name: 'Shirt', sku: 'SHIRT-L'),
+        ]);
+
+        /** @var OrderEligibility&MockObject $service */
+        $service = $this->createService(['getAlreadyRequestedQty']);
+        $service->method('getAlreadyRequestedQty')->willReturn([10 => 1]);
+
+        $result = $service->getEligibleItems($order);
+
+        $this->assertCount(1, $result);
+        $this->assertSame(1, $result[0]['qty_already_requested']);
+        $this->assertSame(2, $result[0]['qty_available']);
+    }
+
+    public function testGetEligibleItemsReturnsCorrectStructure(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getEntityId')->willReturn(1);
+        $order->method('getItems')->willReturn([
+            $this->createOrderItem(parentItemId: null, productType: 'simple', itemId: 10, qtyOrdered: 2, name: 'Blue Hat', sku: 'HAT-BL'),
+        ]);
+
+        /** @var OrderEligibility&MockObject $service */
+        $service = $this->createService(['getAlreadyRequestedQty']);
+        $service->method('getAlreadyRequestedQty')->willReturn([]);
+
+        $result = $service->getEligibleItems($order);
+
+        $this->assertCount(1, $result);
+        $this->assertSame([
+            'order_item_id' => 10,
+            'name' => 'Blue Hat',
+            'sku' => 'HAT-BL',
+            'qty_ordered' => 2,
+            'qty_already_requested' => 0,
+            'qty_available' => 2,
+        ], $result[0]);
+    }
+
+    public function testGetEligibleItemsIncludesConfigurableProducts(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getEntityId')->willReturn(1);
+        $order->method('getItems')->willReturn([
+            $this->createOrderItem(parentItemId: null, productType: 'configurable', itemId: 20, qtyOrdered: 1, name: 'T-Shirt', sku: 'TSHIRT-M'),
+        ]);
+
+        /** @var OrderEligibility&MockObject $service */
+        $service = $this->createService(['getAlreadyRequestedQty']);
+        $service->method('getAlreadyRequestedQty')->willReturn([]);
+
+        $result = $service->getEligibleItems($order);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('configurable', 'configurable');
+        $this->assertSame(20, $result[0]['order_item_id']);
+    }
+
+    public function testGetEligibleItemsFiltersMultipleItemTypes(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getEntityId')->willReturn(1);
+        $order->method('getItems')->willReturn([
+            $this->createOrderItem(parentItemId: null, productType: 'simple', itemId: 1, qtyOrdered: 2, name: 'Book', sku: 'BOOK-1'),
+            $this->createOrderItem(parentItemId: null, productType: 'virtual', itemId: 2, qtyOrdered: 1),
+            $this->createOrderItem(parentItemId: 1, productType: 'simple', itemId: 3, qtyOrdered: 1),
+            $this->createOrderItem(parentItemId: null, productType: 'downloadable', itemId: 4, qtyOrdered: 1),
+            $this->createOrderItem(parentItemId: null, productType: 'simple', itemId: 5, qtyOrdered: 1, name: 'Pen', sku: 'PEN-1'),
+        ]);
+
+        /** @var OrderEligibility&MockObject $service */
+        $service = $this->createService(['getAlreadyRequestedQty']);
+        $service->method('getAlreadyRequestedQty')->willReturn([]);
+
+        $result = $service->getEligibleItems($order);
+
+        $this->assertCount(2, $result);
+        $this->assertSame(1, $result[0]['order_item_id']);
+        $this->assertSame(5, $result[1]['order_item_id']);
+    }
+}

--- a/Test/Unit/Service/RmaSubmitServiceTest.php
+++ b/Test/Unit/Service/RmaSubmitServiceTest.php
@@ -199,20 +199,19 @@ class RmaSubmitServiceTest extends TestCase
         $statusItem->method('getEntityId')->willReturn(1);
 
         $statusCollection = $this->createMock(\MageOS\RMA\Model\ResourceModel\Status\Collection::class);
-        $statusCollection->method('addFieldToFilter')->willReturnSelf();
         $statusCollection->method('setPageSize')->willReturnSelf();
         $statusCollection->method('getFirstItem')->willReturn($statusItem);
+
+        $statusCollection->expects($this->once())
+            ->method('addFieldToFilter')
+            ->with(\MageOS\RMA\Api\Data\StatusInterface::CODE, StatusCodes::NEW_REQUEST)
+            ->willReturnSelf();
 
         $this->statusCollectionFactory->method('create')->willReturn($statusCollection);
 
         $rma = $this->createMock(RMAInterface::class);
         $rma->method('getEntityId')->willReturn(10);
         $this->rmaFactory->method('create')->willReturn($rma);
-
-        $statusCollection->expects($this->once())
-            ->method('addFieldToFilter')
-            ->with(\MageOS\RMA\Api\Data\StatusInterface::CODE, StatusCodes::NEW_REQUEST)
-            ->willReturnSelf();
 
         $this->orderEligibility->method('getEligibleItems')->willReturn([]);
         $this->attachmentService->method('saveFromJson');
@@ -240,20 +239,19 @@ class RmaSubmitServiceTest extends TestCase
         $statusItem->method('getEntityId')->willReturn(2);
 
         $statusCollection = $this->createMock(\MageOS\RMA\Model\ResourceModel\Status\Collection::class);
-        $statusCollection->method('addFieldToFilter')->willReturnSelf();
         $statusCollection->method('setPageSize')->willReturnSelf();
         $statusCollection->method('getFirstItem')->willReturn($statusItem);
+
+        $statusCollection->expects($this->once())
+            ->method('addFieldToFilter')
+            ->with(\MageOS\RMA\Api\Data\StatusInterface::CODE, StatusCodes::APPROVED)
+            ->willReturnSelf();
 
         $this->statusCollectionFactory->method('create')->willReturn($statusCollection);
 
         $rma = $this->createMock(RMAInterface::class);
         $rma->method('getEntityId')->willReturn(10);
         $this->rmaFactory->method('create')->willReturn($rma);
-
-        $statusCollection->expects($this->once())
-            ->method('addFieldToFilter')
-            ->with(\MageOS\RMA\Api\Data\StatusInterface::CODE, StatusCodes::APPROVED)
-            ->willReturnSelf();
 
         $this->orderEligibility->method('getEligibleItems')->willReturn([]);
         $this->attachmentService->method('saveFromJson');

--- a/Test/Unit/Service/RmaSubmitServiceTest.php
+++ b/Test/Unit/Service/RmaSubmitServiceTest.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MageOS\RMA\Test\Unit\Service;
+
+use MageOS\RMA\Api\Data\RMAInterface;
+use MageOS\RMA\Api\Data\RMAInterfaceFactory;
+use MageOS\RMA\Api\ItemRepositoryInterface;
+use MageOS\RMA\Api\RMARepositoryInterface;
+use MageOS\RMA\Helper\ModuleConfig;
+use MageOS\RMA\Model\Item;
+use MageOS\RMA\Model\ItemFactory;
+use MageOS\RMA\Model\RMA\StatusCodes;
+use MageOS\RMA\Model\ResourceModel\Status\CollectionFactory as StatusCollectionFactory;
+use MageOS\RMA\Service\AttachmentService;
+use MageOS\RMA\Service\OrderEligibility;
+use MageOS\RMA\Service\RmaSubmitService;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Sales\Api\Data\OrderInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class RmaSubmitServiceTest extends TestCase
+{
+    private RMARepositoryInterface&MockObject $rmaRepository;
+    private RMAInterfaceFactory&MockObject $rmaFactory;
+    private ItemFactory&MockObject $itemFactory;
+    private ItemRepositoryInterface&MockObject $itemRepository;
+    private StatusCollectionFactory&MockObject $statusCollectionFactory;
+    private ModuleConfig&MockObject $moduleConfig;
+    private AttachmentService&MockObject $attachmentService;
+    private OrderEligibility&MockObject $orderEligibility;
+    private ResourceConnection&MockObject $resourceConnection;
+    private AdapterInterface&MockObject $connection;
+    private RmaSubmitService $service;
+
+    protected function setUp(): void
+    {
+        $this->rmaRepository = $this->createMock(RMARepositoryInterface::class);
+        $this->rmaFactory = $this->createMock(RMAInterfaceFactory::class);
+        $this->itemFactory = $this->createMock(ItemFactory::class);
+        $this->itemRepository = $this->createMock(ItemRepositoryInterface::class);
+        $this->statusCollectionFactory = $this->createMock(StatusCollectionFactory::class);
+        $this->moduleConfig = $this->createMock(ModuleConfig::class);
+        $this->attachmentService = $this->createMock(AttachmentService::class);
+        $this->orderEligibility = $this->createMock(OrderEligibility::class);
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->connection = $this->createMock(AdapterInterface::class);
+
+        $this->resourceConnection->method('getConnection')->willReturn($this->connection);
+
+        $this->service = new RmaSubmitService(
+            $this->rmaRepository,
+            $this->rmaFactory,
+            $this->itemFactory,
+            $this->itemRepository,
+            $this->statusCollectionFactory,
+            $this->moduleConfig,
+            $this->attachmentService,
+            $this->orderEligibility,
+            $this->resourceConnection
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // getSelectedItems
+    // -------------------------------------------------------------------------
+
+    public function testGetSelectedItemsFiltersOutUnselectedItems(): void
+    {
+        $itemsData = [
+            10 => ['selected' => '', 'qty_requested' => 1],
+            20 => ['selected' => '1', 'qty_requested' => 2],
+        ];
+
+        $result = $this->service->getSelectedItems($itemsData);
+
+        $this->assertArrayNotHasKey(10, $result);
+        $this->assertArrayHasKey(20, $result);
+    }
+
+    public function testGetSelectedItemsFiltersOutZeroQty(): void
+    {
+        $itemsData = [
+            10 => ['selected' => '1', 'qty_requested' => 0],
+            20 => ['selected' => '1', 'qty_requested' => 2],
+        ];
+
+        $result = $this->service->getSelectedItems($itemsData);
+
+        $this->assertArrayNotHasKey(10, $result);
+        $this->assertArrayHasKey(20, $result);
+    }
+
+    public function testGetSelectedItemsFiltersOutNegativeQty(): void
+    {
+        $itemsData = [
+            10 => ['selected' => '1', 'qty_requested' => -1],
+        ];
+
+        $result = $this->service->getSelectedItems($itemsData);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGetSelectedItemsReturnsCorrectStructure(): void
+    {
+        $itemsData = [
+            10 => ['selected' => '1', 'qty_requested' => 2, 'condition_id' => 3],
+            20 => ['selected' => '1', 'qty_requested' => 1],
+        ];
+
+        $result = $this->service->getSelectedItems($itemsData);
+
+        $this->assertSame(['qty_requested' => 2, 'condition_id' => 3], $result[10]);
+        $this->assertSame(['qty_requested' => 1, 'condition_id' => null], $result[20]);
+    }
+
+    public function testGetSelectedItemsReturnsEmptyArrayWhenNoItemsSelected(): void
+    {
+        $result = $this->service->getSelectedItems([]);
+
+        $this->assertSame([], $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // createRma
+    // -------------------------------------------------------------------------
+
+    public function testCreateRmaThrowsWhenReasonIdIsMissing(): void
+    {
+        $this->expectException(LocalizedException::class);
+
+        $this->service->createRma(
+            order: $this->createMock(OrderInterface::class),
+            customerId: 1,
+            customerEmail: 'test@example.com',
+            customerName: 'Test User',
+            reasonId: 0,
+            resolutionTypeId: 1,
+            selectedItems: []
+        );
+    }
+
+    public function testCreateRmaThrowsWhenResolutionTypeIdIsMissing(): void
+    {
+        $this->expectException(LocalizedException::class);
+
+        $this->service->createRma(
+            order: $this->createMock(OrderInterface::class),
+            customerId: 1,
+            customerEmail: 'test@example.com',
+            customerName: 'Test User',
+            reasonId: 1,
+            resolutionTypeId: 0,
+            selectedItems: []
+        );
+    }
+
+    public function testCreateRmaThrowsWhenStatusNotFound(): void
+    {
+        $this->expectException(LocalizedException::class);
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getStoreId')->willReturn(1);
+
+        $this->moduleConfig->method('isAutoApproveEnabled')->willReturn(false);
+
+        $statusCollection = $this->createMock(\MageOS\RMA\Model\ResourceModel\Status\Collection::class);
+        $statusCollection->method('addFieldToFilter')->willReturnSelf();
+        $statusCollection->method('setPageSize')->willReturnSelf();
+        $statusCollection->method('getFirstItem')->willReturn(new \Magento\Framework\DataObject());
+
+        $this->statusCollectionFactory->method('create')->willReturn($statusCollection);
+
+        $this->service->createRma(
+            order: $order,
+            customerId: 1,
+            customerEmail: 'test@example.com',
+            customerName: 'Test User',
+            reasonId: 1,
+            resolutionTypeId: 1,
+            selectedItems: []
+        );
+    }
+
+    public function testCreateRmaSetsNewRequestStatusWhenAutoApproveDisabled(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getStoreId')->willReturn(1);
+        $order->method('getEntityId')->willReturn(100);
+
+        $this->moduleConfig->method('isAutoApproveEnabled')->with(1)->willReturn(false);
+
+        $statusItem = $this->createMock(\MageOS\RMA\Api\Data\StatusInterface::class);
+        $statusItem->method('getEntityId')->willReturn(1);
+
+        $statusCollection = $this->createMock(\MageOS\RMA\Model\ResourceModel\Status\Collection::class);
+        $statusCollection->method('addFieldToFilter')->willReturnSelf();
+        $statusCollection->method('setPageSize')->willReturnSelf();
+        $statusCollection->method('getFirstItem')->willReturn($statusItem);
+
+        $this->statusCollectionFactory->method('create')->willReturn($statusCollection);
+
+        $rma = $this->createMock(RMAInterface::class);
+        $rma->method('getEntityId')->willReturn(10);
+        $this->rmaFactory->method('create')->willReturn($rma);
+
+        $statusCollection->expects($this->once())
+            ->method('addFieldToFilter')
+            ->with(\MageOS\RMA\Api\Data\StatusInterface::CODE, StatusCodes::NEW_REQUEST)
+            ->willReturnSelf();
+
+        $this->orderEligibility->method('getEligibleItems')->willReturn([]);
+        $this->attachmentService->method('saveFromJson');
+
+        $this->service->createRma(
+            order: $order,
+            customerId: 1,
+            customerEmail: 'test@example.com',
+            customerName: 'Test User',
+            reasonId: 1,
+            resolutionTypeId: 1,
+            selectedItems: []
+        );
+    }
+
+    public function testCreateRmaSetsApprovedStatusWhenAutoApproveEnabled(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getStoreId')->willReturn(1);
+        $order->method('getEntityId')->willReturn(100);
+
+        $this->moduleConfig->method('isAutoApproveEnabled')->with(1)->willReturn(true);
+
+        $statusItem = $this->createMock(\MageOS\RMA\Api\Data\StatusInterface::class);
+        $statusItem->method('getEntityId')->willReturn(2);
+
+        $statusCollection = $this->createMock(\MageOS\RMA\Model\ResourceModel\Status\Collection::class);
+        $statusCollection->method('addFieldToFilter')->willReturnSelf();
+        $statusCollection->method('setPageSize')->willReturnSelf();
+        $statusCollection->method('getFirstItem')->willReturn($statusItem);
+
+        $this->statusCollectionFactory->method('create')->willReturn($statusCollection);
+
+        $rma = $this->createMock(RMAInterface::class);
+        $rma->method('getEntityId')->willReturn(10);
+        $this->rmaFactory->method('create')->willReturn($rma);
+
+        $statusCollection->expects($this->once())
+            ->method('addFieldToFilter')
+            ->with(\MageOS\RMA\Api\Data\StatusInterface::CODE, StatusCodes::APPROVED)
+            ->willReturnSelf();
+
+        $this->orderEligibility->method('getEligibleItems')->willReturn([]);
+        $this->attachmentService->method('saveFromJson');
+
+        $this->service->createRma(
+            order: $order,
+            customerId: 1,
+            customerEmail: 'test@example.com',
+            customerName: 'Test User',
+            reasonId: 1,
+            resolutionTypeId: 1,
+            selectedItems: []
+        );
+    }
+
+    public function testCreateRmaRollsBackTransactionOnException(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getStoreId')->willReturn(1);
+        $order->method('getEntityId')->willReturn(100);
+
+        $this->moduleConfig->method('isAutoApproveEnabled')->willReturn(false);
+
+        $statusItem = $this->createMock(\MageOS\RMA\Api\Data\StatusInterface::class);
+        $statusItem->method('getEntityId')->willReturn(1);
+
+        $statusCollection = $this->createMock(\MageOS\RMA\Model\ResourceModel\Status\Collection::class);
+        $statusCollection->method('addFieldToFilter')->willReturnSelf();
+        $statusCollection->method('setPageSize')->willReturnSelf();
+        $statusCollection->method('getFirstItem')->willReturn($statusItem);
+        $this->statusCollectionFactory->method('create')->willReturn($statusCollection);
+
+        $rma = $this->createMock(RMAInterface::class);
+        $rma->method('getEntityId')->willReturn(10);
+        $this->rmaFactory->method('create')->willReturn($rma);
+
+        $this->rmaRepository->method('save')->willThrowException(new \RuntimeException('DB error'));
+
+        $this->connection->expects($this->once())->method('beginTransaction');
+        $this->connection->expects($this->once())->method('rollBack');
+        $this->connection->expects($this->never())->method('commit');
+
+        $this->expectException(\RuntimeException::class);
+
+        $this->service->createRma(
+            order: $order,
+            customerId: 1,
+            customerEmail: 'test@example.com',
+            customerName: 'Test User',
+            reasonId: 1,
+            resolutionTypeId: 1,
+            selectedItems: []
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // saveItems
+    // -------------------------------------------------------------------------
+
+    public function testSaveItemsThrowsWhenItemNotEligible(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessageMatches('/not eligible/');
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getIncrementId')->willReturn('000000001');
+        $order->method('getEntityId')->willReturn(100);
+
+        $this->orderEligibility->method('getEligibleItems')->with($order)->willReturn([
+            ['order_item_id' => 5, 'qty_available' => 2],
+        ]);
+
+        $this->service->saveItems(
+            rmaId: 1,
+            selectedItems: [99 => ['qty_requested' => 1, 'condition_id' => null]],
+            order: $order
+        );
+    }
+
+    public function testSaveItemsThrowsWhenQtyExceedsAvailable(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessageMatches('/exceeds available/');
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getIncrementId')->willReturn('000000001');
+        $order->method('getEntityId')->willReturn(100);
+
+        $this->orderEligibility->method('getEligibleItems')->with($order)->willReturn([
+            ['order_item_id' => 5, 'qty_available' => 1],
+        ]);
+
+        $this->service->saveItems(
+            rmaId: 1,
+            selectedItems: [5 => ['qty_requested' => 3, 'condition_id' => null]],
+            order: $order
+        );
+    }
+
+    public function testSaveItemsPersistsEachEligibleItem(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getEntityId')->willReturn(100);
+
+        $this->orderEligibility->method('getEligibleItems')->willReturn([
+            ['order_item_id' => 1, 'qty_available' => 2],
+            ['order_item_id' => 2, 'qty_available' => 1],
+        ]);
+
+        $item = $this->createMock(Item::class);
+        $this->itemFactory->method('create')->willReturn($item);
+        $this->itemRepository->expects($this->exactly(2))->method('save');
+
+        $this->service->saveItems(
+            rmaId: 10,
+            selectedItems: [
+                1 => ['qty_requested' => 1, 'condition_id' => null],
+                2 => ['qty_requested' => 1, 'condition_id' => 3],
+            ],
+            order: $order
+        );
+    }
+}


### PR DESCRIPTION
Includes unit testing for RMA, I didn't cover like all cases but the ones I think have higher priority to be validated.
This should handle the issue https://github.com/mage-os-lab/module-rma/issues/ 

Test/Unit/Service/OrderEligibilityTest.php — 16 tests                                                                                                                                                                                  
                                          
  isOrderEligible                                                                                                                                                                                                                        
  - Returns false when module is disabled                                                                                                                                                                                                
  - Returns false when order status is not in the allowlist                                                                                                                                                                              
  - Returns false when order is outside the return period                                                                                                                                                                                
  - Returns false when no eligible items remain                                                                                                                                                                                        
  - Returns true when all conditions are met                                                                                                                                                                                             
  - Returns true when return period is set to unlimited (0) 
                                                                                                                                                                                                                                         
  getEligibleItems                                                                                                                                                                                                                       
  - Skips child items (items with parentItemId)                                                                                                                                                                                          
  - Skips virtual products                                                                                                                                                                                                               
  - Skips downloadable products                                                                                                                                                                                                          
  - Skips items where available qty is zero (fully requested)                                                                                                                                                                            
  - Correctly deducts already-requested qty from available qty                                                                                                                                                                           
  - Returns the correct data structure (all 6 fields)         
  - Includes configurable products                                                                                                                                                                                                       
  - Filters correctly across a mixed set of item types                                                                                                                                                                                   
                                                                                                                                                                                                                                         
  ---                                                                                                                                                                                                                                    
  Test/Unit/Service/RmaSubmitServiceTest.php — 12 tests                                                                                                                                                                                  
                                                            
  getSelectedItems                                                                                                                                                                                                                       
  - Filters out unselected items (selected = '')            
  - Filters out items with zero qty                                                                                                                                                                                                      
  - Filters out items with negative qty                     
  - Returns correct structure (condition_id nullable, keys are int order item IDs)                                                                                                                                                       
  - Returns empty array on empty input                      
                                              
  createRma                                                                                                                                                                                                                              
  - Throws LocalizedException when reasonId is missing
  - Throws LocalizedException when resolutionTypeId is missing                                                                                                                                                                           
  - Throws LocalizedException when no matching status is found
  - Queries for new_request status when auto-approve is disabled                                                                                                                                                                         
  - Queries for approved status when auto-approve is enabled                                                                                                                                                                             
  - Rolls back the DB transaction on exception, never calls commit()
                                                                                                                                                                                                                                         
  saveItems                                                 
  - Throws LocalizedException when item ID is not in the eligible list                                                                                                                                                                   
  - Throws LocalizedException when requested qty exceeds available qty
  - Calls itemRepository->save() for each valid selected item                                                                                                                                                                            
                                                            
  ---                                                                                                                                                                                                                                    
  Test/Unit/Model/RMA/StatusResolverTest.php — 7 tests      
                                                                                                                                                                                                                                         
  getCodeById                                               
  - Fetches from repository on cache miss
  - Returns cached value on subsequent calls (repository called once total)                                                                                                                                                              
  - Returns null gracefully on NoSuchEntityException                       
                                                                                                                                                                                                                                         
  getIdByCode                                               
  - Fetches via getList and returns the first result's ID
  - Returns cached value on subsequent calls (no second getList call)                                                                                                                                                                    
  - Returns null when no results are found                                                                                                                                                                                               
  - Reuses cache populated by a prior getCodeById call via array_flip — getList never called  