### PR TITLE
Disable RMA feature at installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Module settings are located at **Stores > Configuration > Sales > RMA - Return M
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| Enable RMA | Yes/No | Yes | Enable or disable the RMA feature (scope: website) |
+| Enable RMA | Yes/No | No | Enable or disable the RMA feature (scope: website) |
 | Increment ID Prefix | Text | `RMA-` | Prefix for the return increment ID (e.g. `RMA-000001`) |
 | Return Period (Days) | Numeric | `30` | Number of days after order placement within which a return can be requested |
 

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -3,7 +3,7 @@
     <default>
         <rma>
             <general>
-                <enabled>1</enabled>
+                <enabled>0</enabled>
                 <increment_id_prefix>RMA-</increment_id_prefix>
                 <return_period>30</return_period>
             </general>


### PR DESCRIPTION
Per #33 and other discussions I've had (last tech meeting, and others): The general agreement is that this should be bundled with Mage-OS 3.0, but that it should be disabled unless/until merchants turn it on, to minimize potential for issues.

It's not unusual for extensions to default to disabled anyway; configuration is a necessary part of setup.

Along with that, we'll do very big messaging about this being a new feature people should take advantage of (whether they use Mage-OS or not).

@SamueleMartini please merge and tag this, then we'll get this bundled in https://github.com/mage-os/generate-mirror-repo-js/pull/313 . Thanks!