### PR TITLE
Fix unqualified column reference

### DIFF
--- a/Block/Customer/Rma/ListRma.php
+++ b/Block/Customer/Rma/ListRma.php
@@ -48,7 +48,7 @@ class ListRma extends Template
         if ($this->rmaCollection === null) {
             $this->rmaCollection = $this->collectionFactory->create();
             $this->rmaCollection->joinSalesOrder();
-            $this->rmaCollection->addFieldToFilter('customer_id', $customerId);
+            $this->rmaCollection->addFieldToFilter('main_table.customer_id', $customerId);
             $this->rmaCollection->setOrder('created_at', 'desc');
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [2.3.0] - Unreleased
+## [2.3.1]
+### Fixed
+- Fix unqualified column reference in customer RMA list (#36)
+
+## [2.3.0] - 2026-05-10
 
 ### Changed
 - **Enable RMA** system configuration default switched from `Yes` to `No` at installation — RMA feature must now be explicitly enabled by the admin after install (#34)


### PR DESCRIPTION
Fixes column 'customer_id' in where clause is ambiguous issue

Fixes https://github.com/mage-os/module-rma/issues/35 