### PR TITLE
ci: add check-extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  compute_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.supported-version.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: graycoreio/github-actions-magento2/supported-version@v8.7.0 # x-release-please-version
+        id: supported-version
+      - run: echo ${{ steps.supported-version.outputs.matrix }}
+  check-extension:
+    needs: compute_matrix
+    uses: graycoreio/github-actions-magento2/.github/workflows/check-extension.yaml@v8.7.0 # x-release-please-version
+    with:
+      matrix: ${{ needs.compute_matrix.outputs.matrix }}


### PR DESCRIPTION
Adds the [`check-extension` workflow](https://github.com/graycoreio/github-actions-magento2/blob/main/docs/workflows/check-extension.md) for basic extension CI.