### PR TITLE
fix(composer): pin dependencies to the Magento 2.4.9 line

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
     "description": "Return Merchandise Authorization",
     "type": "magento2-module",
     "require": {
-        "magento/framework": "*",
-        "magento/module-sales": "*",
-        "magento/module-webapi": "*",
-        "magento/module-graph-ql": "*",
-        "php": ">=8.3"
+        "magento/framework": "^103.0.9",
+        "magento/module-sales": "^103.0.9",
+        "magento/module-webapi": "^100.4.8",
+        "magento/module-graph-ql": "^100.4.9",
+        "php": "~8.3.0||~8.4.0||~8.5.0"
     },
     "authors": [
         {


### PR DESCRIPTION
The module declared "*" for every magento/* dependency and ">=8.3" for PHP, so Composer accepted it on any Magento version. That is the monorepo convention (mage-os/magento2 core modules also use "*", and the package-split tooling rewrites them at release time), but a standalone extension repo gets no such rewrite.

MageOS 3 is based on Magento 2.4.9, so pin to the versions the 2.4.9 metapackage ships:

  magento/framework       103.0.9
  magento/module-sales    103.0.9
  magento/module-graph-ql 100.4.9
  magento/module-webapi   100.4.8

^103.0.9 matches 103.0.9 and its -pN security patches while rejecting 103.0.8 and below, so the module resolves on 2.4.9 and nothing older. These constraints also hold on Mage-OS itself: mage-os/framework:3.1.0 declares replace: {"magento/framework": "103.0.9"}, and every mage-os module replaces its magento/* counterpart at the same version.

The PHP constraint now mirrors the 2.4.9 metapackage instead of an open-ended >=8.3, which would have admitted PHP 9.

Note for CI: the default `currently-supported` matrix from graycoreio/github-actions-magento2 spans 2.4.6-p15 (PHP 8.2) through 2.4.9. With these constraints three of those four entries can no longer resolve, so the matrix must be narrowed to Mage-OS 3.x / 2.4.9 in the same change that enables it.