### PR TITLE
fix: support PHP 8.2 and declare an open Magento compatibility range

### DIFF
--- a/Api/Data/AttachmentInterface.php
+++ b/Api/Data/AttachmentInterface.php
@@ -9,14 +9,14 @@ namespace MageOS\RMA\Api\Data;
  */
 interface AttachmentInterface
 {
-    const string ENTITY_ID = 'entity_id';
-    const string RMA_ID = 'rma_id';
-    const string COMMENT_ID = 'comment_id';
-    const string FILE_NAME = 'file_name';
-    const string FILE_PATH = 'file_path';
-    const string FILE_SIZE = 'file_size';
-    const string MIME_TYPE = 'mime_type';
-    const string CREATED_AT = 'created_at';
+    const ENTITY_ID = 'entity_id';
+    const RMA_ID = 'rma_id';
+    const COMMENT_ID = 'comment_id';
+    const FILE_NAME = 'file_name';
+    const FILE_PATH = 'file_path';
+    const FILE_SIZE = 'file_size';
+    const MIME_TYPE = 'mime_type';
+    const CREATED_AT = 'created_at';
 
     /**
      * @return int|null

--- a/Api/Data/CommentInterface.php
+++ b/Api/Data/CommentInterface.php
@@ -9,16 +9,16 @@ namespace MageOS\RMA\Api\Data;
  */
 interface CommentInterface
 {
-    const string ENTITY_ID = 'entity_id';
-    const string RMA_ID = 'rma_id';
-    const string AUTHOR_TYPE = 'author_type';
-    const string AUTHOR_NAME = 'author_name';
-    const string COMMENT = 'comment';
-    const string IS_VISIBLE_TO_CUSTOMER = 'is_visible_to_customer';
-    const string CREATED_AT = 'created_at';
+    const ENTITY_ID = 'entity_id';
+    const RMA_ID = 'rma_id';
+    const AUTHOR_TYPE = 'author_type';
+    const AUTHOR_NAME = 'author_name';
+    const COMMENT = 'comment';
+    const IS_VISIBLE_TO_CUSTOMER = 'is_visible_to_customer';
+    const CREATED_AT = 'created_at';
 
-    const string AUTHOR_TYPE_CUSTOMER = 'customer';
-    const string AUTHOR_TYPE_ADMIN = 'admin';
+    const AUTHOR_TYPE_CUSTOMER = 'customer';
+    const AUTHOR_TYPE_ADMIN = 'admin';
 
     /**
      * @return int|null

--- a/Api/Data/ItemConditionInterface.php
+++ b/Api/Data/ItemConditionInterface.php
@@ -9,11 +9,11 @@ namespace MageOS\RMA\Api\Data;
  */
 interface ItemConditionInterface
 {
-    const string ENTITY_ID = 'entity_id';
-    const string CODE = 'code';
-    const string LABEL = 'label';
-    const string IS_ACTIVE = 'is_active';
-    const string SORT_ORDER = 'sort_order';
+    const ENTITY_ID = 'entity_id';
+    const CODE = 'code';
+    const LABEL = 'label';
+    const IS_ACTIVE = 'is_active';
+    const SORT_ORDER = 'sort_order';
 
     /**
      * @return int|null

--- a/Api/Data/ItemInterface.php
+++ b/Api/Data/ItemInterface.php
@@ -9,15 +9,15 @@ namespace MageOS\RMA\Api\Data;
  */
 interface ItemInterface
 {
-    const string ENTITY_ID = 'entity_id';
-    const string RMA_ID = 'rma_id';
-    const string ORDER_ITEM_ID = 'order_item_id';
-    const string QTY_REQUESTED = 'qty_requested';
-    const string QTY_APPROVED = 'qty_approved';
-    const string QTY_RETURNED = 'qty_returned';
-    const string CONDITION_ID = 'condition_id';
-    const string CREATED_AT = 'created_at';
-    const string UPDATED_AT = 'updated_at';
+    const ENTITY_ID = 'entity_id';
+    const RMA_ID = 'rma_id';
+    const ORDER_ITEM_ID = 'order_item_id';
+    const QTY_REQUESTED = 'qty_requested';
+    const QTY_APPROVED = 'qty_approved';
+    const QTY_RETURNED = 'qty_returned';
+    const CONDITION_ID = 'condition_id';
+    const CREATED_AT = 'created_at';
+    const UPDATED_AT = 'updated_at';
 
     /**
      * @return int|null

--- a/Api/Data/RMAInterface.php
+++ b/Api/Data/RMAInterface.php
@@ -9,18 +9,18 @@ namespace MageOS\RMA\Api\Data;
  */
 interface RMAInterface
 {
-    const string ENTITY_ID = 'entity_id';
-    const string INCREMENT_ID = 'increment_id';
-    const string ORDER_ID = 'order_id';
-    const string CUSTOMER_ID = 'customer_id';
-    const string STORE_ID = 'store_id';
-    const string CUSTOMER_EMAIL = 'customer_email';
-    const string CUSTOMER_NAME = 'customer_name';
-    const string STATUS_ID = 'status_id';
-    const string REASON_ID = 'reason_id';
-    const string RESOLUTION_TYPE_ID = 'resolution_type_id';
-    const string CREATED_AT = 'created_at';
-    const string UPDATED_AT = 'updated_at';
+    const ENTITY_ID = 'entity_id';
+    const INCREMENT_ID = 'increment_id';
+    const ORDER_ID = 'order_id';
+    const CUSTOMER_ID = 'customer_id';
+    const STORE_ID = 'store_id';
+    const CUSTOMER_EMAIL = 'customer_email';
+    const CUSTOMER_NAME = 'customer_name';
+    const STATUS_ID = 'status_id';
+    const REASON_ID = 'reason_id';
+    const RESOLUTION_TYPE_ID = 'resolution_type_id';
+    const CREATED_AT = 'created_at';
+    const UPDATED_AT = 'updated_at';
 
     /**
      * @return int|null

--- a/Api/Data/ReasonInterface.php
+++ b/Api/Data/ReasonInterface.php
@@ -9,11 +9,11 @@ namespace MageOS\RMA\Api\Data;
  */
 interface ReasonInterface
 {
-    const string ENTITY_ID = 'entity_id';
-    const string CODE = 'code';
-    const string LABEL = 'label';
-    const string IS_ACTIVE = 'is_active';
-    const string SORT_ORDER = 'sort_order';
+    const ENTITY_ID = 'entity_id';
+    const CODE = 'code';
+    const LABEL = 'label';
+    const IS_ACTIVE = 'is_active';
+    const SORT_ORDER = 'sort_order';
 
     /**
      * @return int|null

--- a/Api/Data/ResolutionTypeInterface.php
+++ b/Api/Data/ResolutionTypeInterface.php
@@ -9,11 +9,11 @@ namespace MageOS\RMA\Api\Data;
  */
 interface ResolutionTypeInterface
 {
-    const string ENTITY_ID = 'entity_id';
-    const string CODE = 'code';
-    const string LABEL = 'label';
-    const string IS_ACTIVE = 'is_active';
-    const string SORT_ORDER = 'sort_order';
+    const ENTITY_ID = 'entity_id';
+    const CODE = 'code';
+    const LABEL = 'label';
+    const IS_ACTIVE = 'is_active';
+    const SORT_ORDER = 'sort_order';
 
     /**
      * @return int|null

--- a/Api/Data/StatusInterface.php
+++ b/Api/Data/StatusInterface.php
@@ -9,11 +9,11 @@ namespace MageOS\RMA\Api\Data;
  */
 interface StatusInterface
 {
-    const string ENTITY_ID = 'entity_id';
-    const string CODE = 'code';
-    const string LABEL = 'label';
-    const string IS_ACTIVE = 'is_active';
-    const string SORT_ORDER = 'sort_order';
+    const ENTITY_ID = 'entity_id';
+    const CODE = 'code';
+    const LABEL = 'label';
+    const IS_ACTIVE = 'is_active';
+    const SORT_ORDER = 'sort_order';
 
     /**
      * @return int|null

--- a/Console/Command/CleanupCommand.php
+++ b/Console/Command/CleanupCommand.php
@@ -21,9 +21,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CleanupCommand extends Command
 {
-    const string OPTION_DAYS = 'days';
-    const string OPTION_DRY_RUN = 'dry-run';
-    const array CLOSED_STATUSES = [
+    const OPTION_DAYS = 'days';
+    const OPTION_DRY_RUN = 'dry-run';
+    const CLOSED_STATUSES = [
         StatusCodes::RESOLVED,
         StatusCodes::REJECTED,
         StatusCodes::CANCELED_BY_CUSTOMER,

--- a/Console/Command/ListCommand.php
+++ b/Console/Command/ListCommand.php
@@ -24,10 +24,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Command
 {
-    const string OPTION_STATUS = 'status';
-    const string OPTION_FROM = 'from';
-    const string OPTION_TO = 'to';
-    const string OPTION_STORE = 'store';
+    const OPTION_STATUS = 'status';
+    const OPTION_FROM = 'from';
+    const OPTION_TO = 'to';
+    const OPTION_STORE = 'store';
 
     /**
      * @param RMARepositoryInterface $rmaRepository

--- a/Console/Command/StatusCommand.php
+++ b/Console/Command/StatusCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class StatusCommand extends Command
 {
-    const string ARG_INCREMENT_ID = 'increment_id';
+    const ARG_INCREMENT_ID = 'increment_id';
 
     /**
      * @param RMARepositoryInterface $rmaRepository

--- a/Controller/Adminhtml/ItemCondition.php
+++ b/Controller/Adminhtml/ItemCondition.php
@@ -6,7 +6,7 @@ namespace MageOS\RMA\Controller\Adminhtml;
 
 abstract class ItemCondition extends AbstractLookupController
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_item_condition';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_item_condition';
 
     /**
      * @return string

--- a/Controller/Adminhtml/ItemCondition/Delete.php
+++ b/Controller/Adminhtml/ItemCondition/Delete.php
@@ -10,7 +10,7 @@ use Magento\Backend\App\Action\Context;
 
 class Delete extends AbstractLookupDelete
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_item_condition';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_item_condition';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/ItemCondition/Edit.php
+++ b/Controller/Adminhtml/ItemCondition/Edit.php
@@ -11,7 +11,7 @@ use Magento\Framework\View\Result\PageFactory;
 
 class Edit extends AbstractLookupEdit
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_item_condition';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_item_condition';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/ItemCondition/InlineEdit.php
+++ b/Controller/Adminhtml/ItemCondition/InlineEdit.php
@@ -11,7 +11,7 @@ use Magento\Framework\Controller\Result\JsonFactory;
 
 class InlineEdit extends AbstractLookupInlineEdit
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_item_condition';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_item_condition';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/ItemCondition/MassDelete.php
+++ b/Controller/Adminhtml/ItemCondition/MassDelete.php
@@ -11,7 +11,7 @@ use Magento\Ui\Component\MassAction\Filter;
 
 class MassDelete extends AbstractLookupMassDelete
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_item_condition';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_item_condition';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/ItemCondition/Save.php
+++ b/Controller/Adminhtml/ItemCondition/Save.php
@@ -12,7 +12,7 @@ use Magento\Framework\App\Request\DataPersistorInterface;
 
 class Save extends AbstractLookupSave
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_item_condition';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_item_condition';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/Order/GetSelected.php
+++ b/Controller/Adminhtml/Order/GetSelected.php
@@ -16,7 +16,7 @@ class GetSelected extends Action implements HttpGetActionInterface
 {
     use OrderOptionFormatter;
 
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_manage';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_manage';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/Order/Items.php
+++ b/Controller/Adminhtml/Order/Items.php
@@ -16,7 +16,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 
 class Items extends Action implements HttpGetActionInterface
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_manage';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_manage';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/Order/Search.php
+++ b/Controller/Adminhtml/Order/Search.php
@@ -18,7 +18,7 @@ class Search extends Action implements HttpGetActionInterface
 {
     use OrderOptionFormatter;
 
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_manage';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_manage';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/Reason.php
+++ b/Controller/Adminhtml/Reason.php
@@ -6,7 +6,7 @@ namespace MageOS\RMA\Controller\Adminhtml;
 
 abstract class Reason extends AbstractLookupController
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_reason';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_reason';
 
     /**
      * @return string

--- a/Controller/Adminhtml/Reason/Delete.php
+++ b/Controller/Adminhtml/Reason/Delete.php
@@ -10,7 +10,7 @@ use Magento\Backend\App\Action\Context;
 
 class Delete extends AbstractLookupDelete
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_reason';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_reason';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/Reason/Edit.php
+++ b/Controller/Adminhtml/Reason/Edit.php
@@ -11,7 +11,7 @@ use Magento\Framework\View\Result\PageFactory;
 
 class Edit extends AbstractLookupEdit
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_reason';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_reason';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/Reason/InlineEdit.php
+++ b/Controller/Adminhtml/Reason/InlineEdit.php
@@ -11,7 +11,7 @@ use Magento\Framework\Controller\Result\JsonFactory;
 
 class InlineEdit extends AbstractLookupInlineEdit
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_reason';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_reason';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/Reason/MassDelete.php
+++ b/Controller/Adminhtml/Reason/MassDelete.php
@@ -11,7 +11,7 @@ use Magento\Ui\Component\MassAction\Filter;
 
 class MassDelete extends AbstractLookupMassDelete
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_reason';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_reason';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/Reason/Save.php
+++ b/Controller/Adminhtml/Reason/Save.php
@@ -12,7 +12,7 @@ use Magento\Framework\App\Request\DataPersistorInterface;
 
 class Save extends AbstractLookupSave
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_reason';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_reason';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/ResolutionType.php
+++ b/Controller/Adminhtml/ResolutionType.php
@@ -6,7 +6,7 @@ namespace MageOS\RMA\Controller\Adminhtml;
 
 abstract class ResolutionType extends AbstractLookupController
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_resolution_type';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_resolution_type';
 
     /**
      * @return string

--- a/Controller/Adminhtml/ResolutionType/Delete.php
+++ b/Controller/Adminhtml/ResolutionType/Delete.php
@@ -10,7 +10,7 @@ use Magento\Backend\App\Action\Context;
 
 class Delete extends AbstractLookupDelete
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_resolution_type';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_resolution_type';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/ResolutionType/Edit.php
+++ b/Controller/Adminhtml/ResolutionType/Edit.php
@@ -11,7 +11,7 @@ use Magento\Framework\View\Result\PageFactory;
 
 class Edit extends AbstractLookupEdit
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_resolution_type';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_resolution_type';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/ResolutionType/InlineEdit.php
+++ b/Controller/Adminhtml/ResolutionType/InlineEdit.php
@@ -11,7 +11,7 @@ use Magento\Framework\Controller\Result\JsonFactory;
 
 class InlineEdit extends AbstractLookupInlineEdit
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_resolution_type';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_resolution_type';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/ResolutionType/MassDelete.php
+++ b/Controller/Adminhtml/ResolutionType/MassDelete.php
@@ -11,7 +11,7 @@ use Magento\Ui\Component\MassAction\Filter;
 
 class MassDelete extends AbstractLookupMassDelete
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_resolution_type';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_resolution_type';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/ResolutionType/Save.php
+++ b/Controller/Adminhtml/ResolutionType/Save.php
@@ -12,7 +12,7 @@ use Magento\Framework\App\Request\DataPersistorInterface;
 
 class Save extends AbstractLookupSave
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_resolution_type';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_resolution_type';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/Rma.php
+++ b/Controller/Adminhtml/Rma.php
@@ -6,7 +6,7 @@ namespace MageOS\RMA\Controller\Adminhtml;
 
 abstract class Rma extends AbstractLookupController
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_manage';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_manage';
 
     /**
      * @return string

--- a/Controller/Adminhtml/Status.php
+++ b/Controller/Adminhtml/Status.php
@@ -6,7 +6,7 @@ namespace MageOS\RMA\Controller\Adminhtml;
 
 abstract class Status extends AbstractLookupController
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_status';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_status';
 
     /**
      * @return string

--- a/Controller/Adminhtml/Status/Delete.php
+++ b/Controller/Adminhtml/Status/Delete.php
@@ -11,7 +11,7 @@ use Magento\Backend\App\Action\Context;
 
 class Delete extends AbstractLookupDelete
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_status';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_status';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/Status/Edit.php
+++ b/Controller/Adminhtml/Status/Edit.php
@@ -11,7 +11,7 @@ use Magento\Framework\View\Result\PageFactory;
 
 class Edit extends AbstractLookupEdit
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_status';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_status';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/Status/InlineEdit.php
+++ b/Controller/Adminhtml/Status/InlineEdit.php
@@ -11,7 +11,7 @@ use Magento\Framework\Controller\Result\JsonFactory;
 
 class InlineEdit extends AbstractLookupInlineEdit
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_status';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_status';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/Status/MassDelete.php
+++ b/Controller/Adminhtml/Status/MassDelete.php
@@ -12,7 +12,7 @@ use Magento\Ui\Component\MassAction\Filter;
 
 class MassDelete extends AbstractLookupMassDelete
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_status';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_status';
 
     /**
      * @param Context $context

--- a/Controller/Adminhtml/Status/Save.php
+++ b/Controller/Adminhtml/Status/Save.php
@@ -12,7 +12,7 @@ use Magento\Framework\App\Request\DataPersistorInterface;
 
 class Save extends AbstractLookupSave
 {
-    const string ADMIN_RESOURCE = 'MageOS_RMA::rma_status';
+    const ADMIN_RESOURCE = 'MageOS_RMA::rma_status';
 
     /**
      * @param Context $context

--- a/Helper/ModuleConfig.php
+++ b/Helper/ModuleConfig.php
@@ -10,29 +10,29 @@ use Magento\Store\Model\StoreManagerInterface;
 
 class ModuleConfig
 {
-    const string SECTION = 'rma/';
+    const SECTION = 'rma/';
 
-    const string GROUP_GENERAL = self::SECTION . 'general/';
-    const string GROUP_POLICY = self::SECTION . 'policy/';
-    const string GROUP_EMAIL = self::SECTION . 'email/';
-    const string GROUP_ATTACHMENTS = self::SECTION . 'attachments/';
+    const GROUP_GENERAL = self::SECTION . 'general/';
+    const GROUP_POLICY = self::SECTION . 'policy/';
+    const GROUP_EMAIL = self::SECTION . 'email/';
+    const GROUP_ATTACHMENTS = self::SECTION . 'attachments/';
 
-    const string XML_PATH_ENABLED = self::GROUP_GENERAL . 'enabled';
-    const string XML_PATH_INCREMENT_ID_PREFIX = self::GROUP_GENERAL . 'increment_id_prefix';
-    const string XML_PATH_RETURN_PERIOD = self::GROUP_GENERAL . 'return_period';
+    const XML_PATH_ENABLED = self::GROUP_GENERAL . 'enabled';
+    const XML_PATH_INCREMENT_ID_PREFIX = self::GROUP_GENERAL . 'increment_id_prefix';
+    const XML_PATH_RETURN_PERIOD = self::GROUP_GENERAL . 'return_period';
 
-    const string XML_PATH_AUTO_APPROVE = self::GROUP_POLICY . 'auto_approve';
-    const string XML_PATH_ALLOWED_ORDER_STATUSES = self::GROUP_POLICY . 'allowed_order_statuses';
+    const XML_PATH_AUTO_APPROVE = self::GROUP_POLICY . 'auto_approve';
+    const XML_PATH_ALLOWED_ORDER_STATUSES = self::GROUP_POLICY . 'allowed_order_statuses';
 
-    const string XML_PATH_SENDER_IDENTITY = self::GROUP_EMAIL . 'sender_identity';
-    const string XML_PATH_CUSTOMER_NEW_TEMPLATE = self::GROUP_EMAIL . 'customer_new_template';
-    const string XML_PATH_CUSTOMER_STATUS_CHANGE_TEMPLATE = self::GROUP_EMAIL . 'customer_status_change_template';
-    const string XML_PATH_ADMIN_NEW_TEMPLATE = self::GROUP_EMAIL . 'admin_new_template';
-    const string XML_PATH_ADMIN_NOTIFY_EMAIL = self::GROUP_EMAIL . 'admin_notify_email';
+    const XML_PATH_SENDER_IDENTITY = self::GROUP_EMAIL . 'sender_identity';
+    const XML_PATH_CUSTOMER_NEW_TEMPLATE = self::GROUP_EMAIL . 'customer_new_template';
+    const XML_PATH_CUSTOMER_STATUS_CHANGE_TEMPLATE = self::GROUP_EMAIL . 'customer_status_change_template';
+    const XML_PATH_ADMIN_NEW_TEMPLATE = self::GROUP_EMAIL . 'admin_new_template';
+    const XML_PATH_ADMIN_NOTIFY_EMAIL = self::GROUP_EMAIL . 'admin_notify_email';
 
-    const string XML_PATH_ALLOWED_EXTENSIONS = self::GROUP_ATTACHMENTS . 'allowed_extensions';
-    const string XML_PATH_MAX_FILE_SIZE = self::GROUP_ATTACHMENTS . 'max_file_size';
-    const string XML_PATH_MAX_FILES = self::GROUP_ATTACHMENTS . 'max_files';
+    const XML_PATH_ALLOWED_EXTENSIONS = self::GROUP_ATTACHMENTS . 'allowed_extensions';
+    const XML_PATH_MAX_FILE_SIZE = self::GROUP_ATTACHMENTS . 'max_file_size';
+    const XML_PATH_MAX_FILES = self::GROUP_ATTACHMENTS . 'max_files';
 
     /**
      * @param ScopeConfigInterface $scopeConfig

--- a/Model/Config/Source/AllowedExtensions.php
+++ b/Model/Config/Source/AllowedExtensions.php
@@ -12,7 +12,7 @@ class AllowedExtensions implements OptionSourceInterface
      * Maps each supported extension to its permitted MIME types.
      * Keeping extension and MIME knowledge co-located avoids them drifting apart.
      */
-    const array EXTENSION_MIME_MAP = [
+    const EXTENSION_MIME_MAP = [
         'jpg'  => ['image/jpeg'],
         'jpeg' => ['image/jpeg'],
         'png'  => ['image/png'],

--- a/Model/RMA/StatusCodes.php
+++ b/Model/RMA/StatusCodes.php
@@ -6,15 +6,15 @@ namespace MageOS\RMA\Model\RMA;
 
 class StatusCodes
 {
-    const string NEW_REQUEST = 'new_request';
-    const string NEED_DETAILS = 'need_details';
-    const string APPROVED = 'approved';
-    const string REJECTED = 'rejected';
-    const string SHIPPED_BY_CUSTOMER = 'shipped_by_customer';
-    const string RECEIVED_BY_ADMIN = 'received_by_admin';
-    const string CANCELED_BY_CUSTOMER = 'canceled_by_customer';
-    const string RESOLVED = 'resolved';
-    const array STATUS_EVENT_MAP = [
+    const NEW_REQUEST = 'new_request';
+    const NEED_DETAILS = 'need_details';
+    const APPROVED = 'approved';
+    const REJECTED = 'rejected';
+    const SHIPPED_BY_CUSTOMER = 'shipped_by_customer';
+    const RECEIVED_BY_ADMIN = 'received_by_admin';
+    const CANCELED_BY_CUSTOMER = 'canceled_by_customer';
+    const RESOLVED = 'resolved';
+    const STATUS_EVENT_MAP = [
         self::APPROVED => 'rma_approved_after',
         self::REJECTED => 'rma_rejected_after',
         self::SHIPPED_BY_CUSTOMER => 'rma_shipped_by_customer_after',
@@ -23,7 +23,7 @@ class StatusCodes
         self::RESOLVED => 'rma_resolved_after',
     ];
 
-    const array PROTECTED_CODES = [
+    const PROTECTED_CODES = [
         self::NEW_REQUEST,
         self::APPROVED,
         self::REJECTED,

--- a/Model/ResourceModel/RMA/Collection.php
+++ b/Model/ResourceModel/RMA/Collection.php
@@ -10,9 +10,9 @@ use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 
 class Collection extends AbstractCollection
 {
-    const string SALES_ORDER_TABLE = 'sales_order';
-    const string SALES_ORDER_ALIAS = 'so';
-    const string ORDER_INCREMENT_ID_COLUMN = 'order_increment_id';
+    const SALES_ORDER_TABLE = 'sales_order';
+    const SALES_ORDER_ALIAS = 'so';
+    const ORDER_INCREMENT_ID_COLUMN = 'order_increment_id';
 
     /**
      * @var string

--- a/Service/AttachmentService.php
+++ b/Service/AttachmentService.php
@@ -24,10 +24,10 @@ use Magento\Framework\Exception\NoSuchEntityException;
 
 class AttachmentService
 {
-    const string BASE_TMP_PATH = 'rma/tmp';
-    const string BASE_PATH = 'rma/attachments';
-    const int BYTES_PER_KB = 1024;
-    const int BYTES_PER_MB = 1024 * 1024;
+    const BASE_TMP_PATH = 'rma/tmp';
+    const BASE_PATH = 'rma/attachments';
+    const BYTES_PER_KB = 1024;
+    const BYTES_PER_MB = 1024 * 1024;
 
     protected WriteInterface $varDirectory;
 

--- a/Service/LabelResolver.php
+++ b/Service/LabelResolver.php
@@ -13,10 +13,10 @@ use Magento\Store\Model\StoreManagerInterface;
 
 class LabelResolver
 {
-    const string TYPE_STATUS = 'status';
-    const string TYPE_REASON = 'reason';
-    const string TYPE_RESOLUTION_TYPE = 'resolution_type';
-    const string TYPE_ITEM_CONDITION = 'item_condition';
+    const TYPE_STATUS = 'status';
+    const TYPE_REASON = 'reason';
+    const TYPE_RESOLUTION_TYPE = 'resolution_type';
+    const TYPE_ITEM_CONDITION = 'item_condition';
 
     /**
      * @param StatusRepositoryInterface $statusRepository

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
     "description": "Return Merchandise Authorization",
     "type": "magento2-module",
     "require": {
-        "magento/framework": "*",
-        "magento/module-sales": "*",
-        "magento/module-webapi": "*",
-        "magento/module-graph-ql": "*",
-        "php": ">=8.3"
+        "magento/framework": "^103.0",
+        "magento/module-sales": "^103.0",
+        "magento/module-webapi": "^100.4",
+        "magento/module-graph-ql": "^100.4",
+        "php": "~8.2.0||~8.3.0||~8.4.0||~8.5.0"
     },
     "authors": [
         {


### PR DESCRIPTION
## What

Lower the PHP floor to 8.2 and replace the `*` dependency constraints with an open, bounded range — so the module installs on every Magento the upstream still supports, not just 2.4.9.

## Why

- `php: ">=8.3"` blocked merchants on Magento 2.4.7/2.4.8 running PHP 8.2 (a supported combination).
- `magento/*: "*"` declared no compatibility at all. `*` is the monorepo convention (core modules rely on the package-split tooling to rewrite it); a standalone repo ships it literally.

## Changes

- **PHP 8.2**: removed typed class constants (`const string FOO`, PHP 8.3+) — the only thing requiring 8.3. 134 declarations across 45 files. Behaviour-neutral: typed constants only guard against a child redeclaring with an incompatible type; values/visibility unchanged. Unit suite identical before/after.
- **composer.json**:
  - `php`: `~8.2.0||~8.3.0||~8.4.0||~8.5.0`
  - `magento/framework`, `magento/module-sales`: `^103.0`
  - `magento/module-webapi`, `magento/module-graph-ql`: `^100.4`

  (caret form matching sibling Mage-OS modules; anchored per package version line)

## Tested

Verified end-to-end on a real install, not just CI:

- **Magento 2.4.6-p15**, **PHP 8.2.30**, warden (MariaDB 10.6, OpenSearch 2.5)
- `setup:upgrade` + `setup:di:compile` succeed on 8.2 (both generated factories created)
- Placed an order and ran the full RMA flow in admin: **created RMA-000000001 and transitioned it to Resolved**
- composer dry-runs resolve against 2.4.6, 2.4.8 and 2.4.9

Installs on Magento Open Source 2.4.6–2.4.9 and Mage-OS 1.x/2.x/3.x.