### PR TITLE
Use full qalified class names in API interfaces to support swagger generation

### DIFF
--- a/Api/AttachmentRepositoryInterface.php
+++ b/Api/AttachmentRepositoryInterface.php
@@ -18,14 +18,14 @@ interface AttachmentRepositoryInterface
 {
     /**
      * @param int $entityId
-     * @return AttachmentInterface
+     * @return \MageOS\RMA\Api\Data\AttachmentInterface
      * @throws NoSuchEntityException
      */
     public function get(int $entityId): AttachmentInterface;
 
     /**
      * @param AttachmentInterface $attachment
-     * @return AttachmentInterface
+     * @return \MageOS\RMA\Api\Data\AttachmentInterface
      * @throws CouldNotSaveException
      */
     public function save(AttachmentInterface $attachment): AttachmentInterface;
@@ -47,7 +47,7 @@ interface AttachmentRepositoryInterface
 
     /**
      * @param SearchCriteriaInterface $searchCriteria
-     * @return AttachmentSearchResultsInterface
+     * @return \MageOS\RMA\Api\Data\AttachmentSearchResultsInterface
      */
     public function getList(SearchCriteriaInterface $searchCriteria): AttachmentSearchResultsInterface;
 }

--- a/Api/CommentRepositoryInterface.php
+++ b/Api/CommentRepositoryInterface.php
@@ -18,14 +18,14 @@ interface CommentRepositoryInterface
 {
     /**
      * @param int $entityId
-     * @return CommentInterface
+     * @return \MageOS\RMA\Api\Data\CommentInterface
      * @throws NoSuchEntityException
      */
     public function get(int $entityId): CommentInterface;
 
     /**
      * @param CommentInterface $comment
-     * @return CommentInterface
+     * @return \MageOS\RMA\Api\Data\CommentInterface
      * @throws CouldNotSaveException
      */
     public function save(CommentInterface $comment): CommentInterface;
@@ -47,7 +47,7 @@ interface CommentRepositoryInterface
 
     /**
      * @param SearchCriteriaInterface $searchCriteria
-     * @return CommentSearchResultsInterface
+     * @return \MageOS\RMA\Api\Data\CommentSearchResultsInterface
      */
     public function getList(SearchCriteriaInterface $searchCriteria): CommentSearchResultsInterface;
 }

--- a/Api/Data/AttachmentSearchResultsInterface.php
+++ b/Api/Data/AttachmentSearchResultsInterface.php
@@ -12,7 +12,7 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface AttachmentSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return AttachmentInterface[]
+     * @return \MageOS\RMA\Api\Data\AttachmentInterface[]
      */
     public function getItems(): array;
 

--- a/Api/Data/CommentSearchResultsInterface.php
+++ b/Api/Data/CommentSearchResultsInterface.php
@@ -12,7 +12,7 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface CommentSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return CommentInterface[]
+     * @return \MageOS\RMA\Api\Data\CommentInterface[]
      */
     public function getItems(): array;
 

--- a/Api/Data/ItemConditionSearchResultsInterface.php
+++ b/Api/Data/ItemConditionSearchResultsInterface.php
@@ -12,7 +12,7 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface ItemConditionSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return ItemConditionInterface[]
+     * @return \MageOS\RMA\Api\Data\ItemConditionInterface[]
      */
     public function getItems(): array;
 

--- a/Api/Data/ItemSearchResultsInterface.php
+++ b/Api/Data/ItemSearchResultsInterface.php
@@ -12,7 +12,7 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface ItemSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return ItemInterface[]
+     * @return \MageOS\RMA\Api\Data\ItemInterface[]
      */
     public function getItems(): array;
 

--- a/Api/Data/RMASearchResultsInterface.php
+++ b/Api/Data/RMASearchResultsInterface.php
@@ -12,7 +12,7 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface RMASearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return RMAInterface[]
+     * @return \MageOS\RMA\Api\Data\RMAInterface[]
      */
     public function getItems(): array;
 

--- a/Api/Data/ReasonSearchResultsInterface.php
+++ b/Api/Data/ReasonSearchResultsInterface.php
@@ -12,7 +12,7 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface ReasonSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return ReasonInterface[]
+     * @return \MageOS\RMA\Api\Data\ReasonInterface[]
      */
     public function getItems(): array;
 

--- a/Api/Data/ResolutionTypeSearchResultsInterface.php
+++ b/Api/Data/ResolutionTypeSearchResultsInterface.php
@@ -12,7 +12,7 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface ResolutionTypeSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return ResolutionTypeInterface[]
+     * @return \MageOS\RMA\Api\Data\ResolutionTypeInterface[]
      */
     public function getItems(): array;
 

--- a/Api/Data/StatusSearchResultsInterface.php
+++ b/Api/Data/StatusSearchResultsInterface.php
@@ -12,7 +12,7 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface StatusSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return StatusInterface[]
+     * @return \MageOS\RMA\Api\Data\StatusInterface[]
      */
     public function getItems(): array;
 

--- a/Api/ItemConditionRepositoryInterface.php
+++ b/Api/ItemConditionRepositoryInterface.php
@@ -18,14 +18,14 @@ interface ItemConditionRepositoryInterface
 {
     /**
      * @param int $entityId
-     * @return ItemConditionInterface
+     * @return \MageOS\RMA\Api\Data\ItemConditionInterface
      * @throws NoSuchEntityException
      */
     public function get(int $entityId): ItemConditionInterface;
 
     /**
      * @param ItemConditionInterface $itemCondition
-     * @return ItemConditionInterface
+     * @return \MageOS\RMA\Api\Data\ItemConditionInterface
      * @throws CouldNotSaveException
      */
     public function save(ItemConditionInterface $itemCondition): ItemConditionInterface;
@@ -47,7 +47,7 @@ interface ItemConditionRepositoryInterface
 
     /**
      * @param SearchCriteriaInterface $searchCriteria
-     * @return ItemConditionSearchResultsInterface
+     * @return \MageOS\RMA\Api\Data\ItemConditionSearchResultsInterface
      */
     public function getList(SearchCriteriaInterface $searchCriteria): ItemConditionSearchResultsInterface;
 }

--- a/Api/ItemRepositoryInterface.php
+++ b/Api/ItemRepositoryInterface.php
@@ -18,14 +18,14 @@ interface ItemRepositoryInterface
 {
     /**
      * @param int $entityId
-     * @return ItemInterface
+     * @return \MageOS\RMA\Api\Data\ItemInterface
      * @throws NoSuchEntityException
      */
     public function get(int $entityId): ItemInterface;
 
     /**
      * @param ItemInterface $item
-     * @return ItemInterface
+     * @return \MageOS\RMA\Api\Data\ItemInterface
      * @throws CouldNotSaveException
      */
     public function save(ItemInterface $item): ItemInterface;
@@ -47,7 +47,7 @@ interface ItemRepositoryInterface
 
     /**
      * @param SearchCriteriaInterface $searchCriteria
-     * @return ItemSearchResultsInterface
+     * @return \MageOS\RMA\Api\Data\ItemSearchResultsInterface
      */
     public function getList(SearchCriteriaInterface $searchCriteria): ItemSearchResultsInterface;
 }

--- a/Api/RMARepositoryInterface.php
+++ b/Api/RMARepositoryInterface.php
@@ -18,21 +18,21 @@ interface RMARepositoryInterface
 {
     /**
      * @param int $entityId
-     * @return RMAInterface
+     * @return \MageOS\RMA\Api\Data\RMAInterface
      * @throws NoSuchEntityException
      */
     public function get(int $entityId): RMAInterface;
 
     /**
      * @param string $incrementId
-     * @return RMAInterface
+     * @return \MageOS\RMA\Api\Data\RMAInterface
      * @throws NoSuchEntityException
      */
     public function getByIncrementId(string $incrementId): RMAInterface;
 
     /**
      * @param RMAInterface $rma
-     * @return RMAInterface
+     * @return \MageOS\RMA\Api\Data\RMAInterface
      * @throws CouldNotSaveException
      */
     public function save(RMAInterface $rma): RMAInterface;
@@ -54,7 +54,7 @@ interface RMARepositoryInterface
 
     /**
      * @param SearchCriteriaInterface $searchCriteria
-     * @return RMASearchResultsInterface
+     * @return \MageOS\RMA\Api\Data\RMASearchResultsInterface
      */
     public function getList(SearchCriteriaInterface $searchCriteria): RMASearchResultsInterface;
 }

--- a/Api/ReasonRepositoryInterface.php
+++ b/Api/ReasonRepositoryInterface.php
@@ -18,14 +18,14 @@ interface ReasonRepositoryInterface
 {
     /**
      * @param int $entityId
-     * @return ReasonInterface
+     * @return \MageOS\RMA\Api\Data\ReasonInterface
      * @throws NoSuchEntityException
      */
     public function get(int $entityId): ReasonInterface;
 
     /**
      * @param ReasonInterface $reason
-     * @return ReasonInterface
+     * @return \MageOS\RMA\Api\Data\ReasonInterface
      * @throws CouldNotSaveException
      */
     public function save(ReasonInterface $reason): ReasonInterface;
@@ -47,7 +47,7 @@ interface ReasonRepositoryInterface
 
     /**
      * @param SearchCriteriaInterface $searchCriteria
-     * @return ReasonSearchResultsInterface
+     * @return \MageOS\RMA\Api\Data\ReasonSearchResultsInterface
      */
     public function getList(SearchCriteriaInterface $searchCriteria): ReasonSearchResultsInterface;
 }

--- a/Api/ResolutionTypeRepositoryInterface.php
+++ b/Api/ResolutionTypeRepositoryInterface.php
@@ -18,14 +18,14 @@ interface ResolutionTypeRepositoryInterface
 {
     /**
      * @param int $entityId
-     * @return ResolutionTypeInterface
+     * @return \MageOS\RMA\Api\Data\ResolutionTypeInterface
      * @throws NoSuchEntityException
      */
     public function get(int $entityId): ResolutionTypeInterface;
 
     /**
      * @param ResolutionTypeInterface $resolutionType
-     * @return ResolutionTypeInterface
+     * @return \MageOS\RMA\Api\Data\ResolutionTypeInterface
      * @throws CouldNotSaveException
      */
     public function save(ResolutionTypeInterface $resolutionType): ResolutionTypeInterface;
@@ -47,7 +47,7 @@ interface ResolutionTypeRepositoryInterface
 
     /**
      * @param SearchCriteriaInterface $searchCriteria
-     * @return ResolutionTypeSearchResultsInterface
+     * @return \MageOS\RMA\Api\Data\ResolutionTypeSearchResultsInterface
      */
     public function getList(SearchCriteriaInterface $searchCriteria): ResolutionTypeSearchResultsInterface;
 }

--- a/Api/RmaCommentManagementInterface.php
+++ b/Api/RmaCommentManagementInterface.php
@@ -19,7 +19,7 @@ interface RmaCommentManagementInterface
     /**
      * @param int $rmaId
      * @param SearchCriteriaInterface $searchCriteria
-     * @return CommentSearchResultsInterface
+     * @return \MageOS\RMA\Api\Data\CommentSearchResultsInterface
      * @throws NoSuchEntityException
      */
     public function getList(int $rmaId, SearchCriteriaInterface $searchCriteria): CommentSearchResultsInterface;
@@ -27,7 +27,7 @@ interface RmaCommentManagementInterface
     /**
      * @param int $rmaId
      * @param CommentInterface $comment
-     * @return CommentInterface
+     * @return \MageOS\RMA\Api\Data\CommentInterface
      * @throws NoSuchEntityException
      * @throws CouldNotSaveException
      * @throws LocalizedException

--- a/Api/RmaItemManagementInterface.php
+++ b/Api/RmaItemManagementInterface.php
@@ -20,7 +20,7 @@ interface RmaItemManagementInterface
     /**
      * @param int $rmaId
      * @param SearchCriteriaInterface $searchCriteria
-     * @return ItemSearchResultsInterface
+     * @return \MageOS\RMA\Api\Data\ItemSearchResultsInterface
      * @throws NoSuchEntityException
      */
     public function getList(int $rmaId, SearchCriteriaInterface $searchCriteria): ItemSearchResultsInterface;
@@ -28,7 +28,7 @@ interface RmaItemManagementInterface
     /**
      * @param int $rmaId
      * @param ItemInterface $item
-     * @return ItemInterface
+     * @return \MageOS\RMA\Api\Data\ItemInterface
      * @throws NoSuchEntityException
      * @throws CouldNotSaveException
      * @throws LocalizedException

--- a/Api/StatusRepositoryInterface.php
+++ b/Api/StatusRepositoryInterface.php
@@ -18,14 +18,14 @@ interface StatusRepositoryInterface
 {
     /**
      * @param int $entityId
-     * @return StatusInterface
+     * @return \MageOS\RMA\Api\Data\StatusInterface
      * @throws NoSuchEntityException
      */
     public function get(int $entityId): StatusInterface;
 
     /**
      * @param StatusInterface $status
-     * @return StatusInterface
+     * @return \MageOS\RMA\Api\Data\StatusInterface
      * @throws CouldNotSaveException
      */
     public function save(StatusInterface $status): StatusInterface;
@@ -47,7 +47,7 @@ interface StatusRepositoryInterface
 
     /**
      * @param SearchCriteriaInterface $searchCriteria
-     * @return StatusSearchResultsInterface
+     * @return \MageOS\RMA\Api\Data\StatusSearchResultsInterface
      */
     public function getList(SearchCriteriaInterface $searchCriteria): StatusSearchResultsInterface;
 }


### PR DESCRIPTION
Currently Magento's docblock reader that is used for the swagger generation does not support imported class names. Therefore we have to use full qualified class names for param and return annotations.

This fixes #48.