### PR TITLE
fix: fully-qualify item types in Api/Data SearchResults docblocks

### DIFF
--- a/Api/Data/AttachmentSearchResultsInterface.php
+++ b/Api/Data/AttachmentSearchResultsInterface.php
@@ -12,12 +12,12 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface AttachmentSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return AttachmentInterface[]
+     * @return \MageOS\RMA\Api\Data\AttachmentInterface[]
      */
     public function getItems(): array;
 
     /**
-     * @param AttachmentInterface[] $items
+     * @param \MageOS\RMA\Api\Data\AttachmentInterface[] $items
      * @return $this
      */
     public function setItems(array $items): self;

--- a/Api/Data/CommentSearchResultsInterface.php
+++ b/Api/Data/CommentSearchResultsInterface.php
@@ -12,12 +12,12 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface CommentSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return CommentInterface[]
+     * @return \MageOS\RMA\Api\Data\CommentInterface[]
      */
     public function getItems(): array;
 
     /**
-     * @param CommentInterface[] $items
+     * @param \MageOS\RMA\Api\Data\CommentInterface[] $items
      * @return $this
      */
     public function setItems(array $items): self;

--- a/Api/Data/ItemConditionSearchResultsInterface.php
+++ b/Api/Data/ItemConditionSearchResultsInterface.php
@@ -12,12 +12,12 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface ItemConditionSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return ItemConditionInterface[]
+     * @return \MageOS\RMA\Api\Data\ItemConditionInterface[]
      */
     public function getItems(): array;
 
     /**
-     * @param ItemConditionInterface[] $items
+     * @param \MageOS\RMA\Api\Data\ItemConditionInterface[] $items
      * @return $this
      */
     public function setItems(array $items): self;

--- a/Api/Data/ItemSearchResultsInterface.php
+++ b/Api/Data/ItemSearchResultsInterface.php
@@ -12,12 +12,12 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface ItemSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return ItemInterface[]
+     * @return \MageOS\RMA\Api\Data\ItemInterface[]
      */
     public function getItems(): array;
 
     /**
-     * @param ItemInterface[] $items
+     * @param \MageOS\RMA\Api\Data\ItemInterface[] $items
      * @return $this
      */
     public function setItems(array $items): self;

--- a/Api/Data/RMASearchResultsInterface.php
+++ b/Api/Data/RMASearchResultsInterface.php
@@ -12,12 +12,12 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface RMASearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return RMAInterface[]
+     * @return \MageOS\RMA\Api\Data\RMAInterface[]
      */
     public function getItems(): array;
 
     /**
-     * @param RMAInterface[] $items
+     * @param \MageOS\RMA\Api\Data\RMAInterface[] $items
      * @return $this
      */
     public function setItems(array $items): self;

--- a/Api/Data/ReasonSearchResultsInterface.php
+++ b/Api/Data/ReasonSearchResultsInterface.php
@@ -12,12 +12,12 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface ReasonSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return ReasonInterface[]
+     * @return \MageOS\RMA\Api\Data\ReasonInterface[]
      */
     public function getItems(): array;
 
     /**
-     * @param ReasonInterface[] $items
+     * @param \MageOS\RMA\Api\Data\ReasonInterface[] $items
      * @return $this
      */
     public function setItems(array $items): self;

--- a/Api/Data/ResolutionTypeSearchResultsInterface.php
+++ b/Api/Data/ResolutionTypeSearchResultsInterface.php
@@ -12,12 +12,12 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface ResolutionTypeSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return ResolutionTypeInterface[]
+     * @return \MageOS\RMA\Api\Data\ResolutionTypeInterface[]
      */
     public function getItems(): array;
 
     /**
-     * @param ResolutionTypeInterface[] $items
+     * @param \MageOS\RMA\Api\Data\ResolutionTypeInterface[] $items
      * @return $this
      */
     public function setItems(array $items): self;

--- a/Api/Data/StatusSearchResultsInterface.php
+++ b/Api/Data/StatusSearchResultsInterface.php
@@ -12,12 +12,12 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface StatusSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return StatusInterface[]
+     * @return \MageOS\RMA\Api\Data\StatusInterface[]
      */
     public function getItems(): array;
 
     /**
-     * @param StatusInterface[] $items
+     * @param \MageOS\RMA\Api\Data\StatusInterface[] $items
      * @return $this
      */
     public function setItems(array $items): self;


### PR DESCRIPTION
## Summary

Every REST list endpoint the module ships (`V1/rma`, `V1/rma/*/comments`, `V1/rma/*/attachments`, `V1/rma/*/items`, `V1/rma/reasons`, `V1/rma/statuses`, `V1/rma/resolution-types`, `V1/rma/item-conditions`) currently fails with a 500:

```
{"message":"Class \"CommentInterface\" does not exist", ...
  #0 …/MethodsMap.php(166): ReflectionClass->__construct('CommentInterface')
  #3 …/DataObjectProcessor->buildOutputDataArray(MageOS\RMA\Model\Comment, 'CommentInterface')
  #4 …/ServiceOutputProcessor->convertValue(
        MageOS\RMA\Model\Data\CommentSearchResults,
        '\\MageOS\\RMA\\Api\\Data\\CommentSearchResultsInterface')
}
```

Each `Api/Data/*SearchResultsInterface.php` in the module declares its item type in PHPDoc using the short class name:

```php
namespace MageOS\RMA\Api\Data;

use Magento\Framework\Api\SearchResultsInterface;

interface CommentSearchResultsInterface extends SearchResultsInterface
{
    /**
     * @return CommentInterface[]
     */
    public function getItems(): array;
}
```

`\Magento\Framework\Reflection\TypeProcessor` resolves PHPDoc short names against the interface's own `use` block only — it does **not** fall back to the file's own namespace — so the string `CommentInterface` reaches `new ReflectionClass()` unqualified and throws.

Reproduced against Magento 2.4.8-p5 (PHP 8.3.16) with `mage-os/module-rma` at `dev-main` (`9a0ae70`).

## Change

Fully qualify item types in `@return` and `@param` on `getItems()` / `setItems()` across all 8 `Api/Data/*SearchResultsInterface.php` files:

```diff
-     * @return CommentInterface[]
+     * @return \MageOS\RMA\Api\Data\CommentInterface[]
```

This matches Magento core convention — e.g. `Magento\Customer\Api\Data\CustomerSearchResultsInterface` and `Magento\Sales\Api\Data\OrderSearchResultInterface` both FQ their item types in PHPDoc for the same reason.

Only the interface docblocks are touched; the concrete `Model\Data\*SearchResults.php` classes already have a matching `use` for the item interface, so they never hit this path.

## Test plan

- [x] `V1/rma/1/comments?searchCriteria[pageSize]=1` reproduces the 500 without the patch.
- [x] Same request returns a valid `CommentSearchResultsInterface` payload after the patch (Magento 2.4.8-p5, PHP 8.3.16).
- [ ] CI green.